### PR TITLE
Update YAML rules to be compatible with OpenRA @ 285e9a8

### DIFF
--- a/rules/barracks.yaml
+++ b/rules/barracks.yaml
@@ -53,9 +53,9 @@ barracks:
 	WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	ProvidesPrerequisite@buildingname:
-	GlobalUpgradable:
+	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.barracks
-		Upgrades: stardecoration
+		Condition: stardecoration
 
 upgrade.barracks:
 	AlwaysVisible:

--- a/rules/building.yaml
+++ b/rules/building.yaml
@@ -22,8 +22,10 @@
 		DestroyedSounds: EXPLHG1.WAV
 	#WithSpriteBody:
 	WithTilesetBody:
-	WithBuildingExplosion:
-		Sequences: building, self_destruct, large_explosion
+	Explodes:
+		Type: Footprint
+		Weapon: BuildingExplode
+		EmptyWeapon: BuildingExplode
 	RepairableBuilding:
 	EmitInfantryOnSell:
 		ActorTypes: light_inf

--- a/rules/construction_yard.yaml
+++ b/rules/construction_yard.yaml
@@ -41,9 +41,9 @@ construction_yard:
 		Sequence: idle-flag
 	PrimaryBuilding:
 	ProvidesPrerequisite@buildingname:
-	GlobalUpgradable:
+	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.conyard
-		Upgrades: stardecoration
+		Condition: stardecoration
 
 upgrade.conyard:
 	AlwaysVisible:

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -3,7 +3,7 @@
 	UpdatesPlayerStatistics:
 	CombatDebugOverlay:
 	ScriptTriggers:
-	UpgradeManager:
+	ConditionManager:
 	Huntable:
 	RenderDebugState:
 

--- a/rules/heavy_factory.yaml
+++ b/rules/heavy_factory.yaml
@@ -58,9 +58,9 @@ heavy_factory:
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 		VisualBounds: 32,32
-	GlobalUpgradable:
+	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.heavy
-		Upgrades: stardecoration
+		Condition: stardecoration
 	#WithSpriteControlGroup:
 
 upgrade.heavy:

--- a/rules/high_tech_factory.yaml
+++ b/rules/high_tech_factory.yaml
@@ -56,9 +56,9 @@ high_tech_factory:
 		Amount: -35
 	SelectionDecorations:
 		VisualBounds: 64,32
-	GlobalUpgradable:
+	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.hightech
-		Upgrades: stardecoration
+		Condition: stardecoration
 	#WithSpriteControlGroup:
 
 upgrade.hightech:

--- a/rules/light_factory.yaml
+++ b/rules/light_factory.yaml
@@ -55,9 +55,9 @@ light_factory:
 	ProvidesPrerequisite@buildingname:
 	Power:
 		Amount: -20
-	GlobalUpgradable:
+	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.light
-		Upgrades: stardecoration
+		Condition: stardecoration
 
 upgrade.light:
 	AlwaysVisible:

--- a/rules/player.yaml
+++ b/rules/player.yaml
@@ -91,6 +91,6 @@ Player:
 		Id: unrestricted
 	EnemyWatcher:
 	HarvesterInsurance:
-	GlobalUpgradeManager:
+	GrantConditionOnPrerequisiteManager:
 	ResourceStorageWarning:
 		AdviceInterval: 26

--- a/rules/sandworm.yaml
+++ b/rules/sandworm.yaml
@@ -49,6 +49,6 @@ sandworm:
 		MovingInterval: 3
 		UpgradeTypes: attacking
 		UpgradeMaxEnabledLevel: 0
-	UpgradeManager:
+	ConditionManager:
 	Buildable:
 		Description: Attracted by vibrations in the sand.\nWill eat units whole and has a large appetite.

--- a/rules/vechicle.yaml
+++ b/rules/vechicle.yaml
@@ -38,10 +38,10 @@
 		VoiceSet: VehicleVoice
 	Carryable:
 		CarryableUpgrades: notmobile
-	WithDecorationCarryable:
-		Image: pips
-		Sequence: pickup-indicator
-		Offset: -12, -12
+	# WithDecoration@Carryable:
+	# 	Image: pips
+	# 	Sequence: pickup-indicator
+	# 	Offset: -12, -12
 	WithDamageOverlay:
 	LeavesTrails:
 		Image: vtrail

--- a/rules/wor.yaml
+++ b/rules/wor.yaml
@@ -55,9 +55,9 @@ wor:
 	WithIdleOverlay@TOP-FLAG:
 		Sequence: idle-top-flag
 	ProvidesPrerequisite@buildingname:
-	GlobalUpgradable:
+	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.wor
-		Upgrades: stardecoration
+		Condition: stardecoration
 
 upgrade.wor:
 	AlwaysVisible:

--- a/rules/world.yaml
+++ b/rules/world.yaml
@@ -44,10 +44,10 @@
 		InternalName: smuggler
 		Selectable: false
 	ResourceType@Spice:
-		ResourceType: 1
+		Type: 1
 		Palette: dune2
 		TerrainType: Spice
-		Variants: spice
+		Sequences: spice
 		MaxDensity: 20
 		ValuePerUnit: 25
 		Name: Spice

--- a/weapons/other.yaml
+++ b/weapons/other.yaml
@@ -171,6 +171,10 @@ CrateExplosion:
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
 
+BuildingExplode:
+	Warhead@1Eff: CreateEffect
+		Explosions: building, self_destruct, large_explosion
+
 UnitExplodeSmall:
 	Warhead@1Eff: CreateEffect
 		Explosions: self_destruct


### PR DESCRIPTION
Hello,

Firstly, thanks for the effort that's gone into this mod. Dune 2 sucked me into the world of RTS.

I couldn't get the mod to launch when compiled against the [latest master of OpenRA (285e9a8)](https://github.com/OpenRA/OpenRA/tree/285e9a803067ddf8bbfee3b89f487029d6118833). After poking around it looks like a bunch of keys in the YAML rule files have diverged. This patch updates the rules enough to get the mod launching based on recent changes in the OpenRA repo.

I'm still getting crashes when moving the MCV or placing a building. I'm happy to dig further, but thought this was PR would be a good place to start.

Open to any feedback you have.

Cheers,
Tate

---

Crash when moving MVC:

```
Exception of type `System.InvalidOperationException`: Unit `moveflsh` does not have a sequence named `idle`
  at OpenRA.Graphics.SequenceProvider.GetSequence (System.String unitName, System.String sequenceName) [0x0005e] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Graphics.Animation.GetSequence (System.String sequenceName) [0x0000d] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Graphics.Animation.PlaySequence (System.String sequenceName) [0x00001] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Graphics.Animation.PlayThen (System.String sequenceName, System.Action after) [0x00023] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Mods.Common.Effects.SpriteEffect..ctor (OpenRA.WPos pos, OpenRA.World world, System.String image, System.String sequence, System.String palette, System.Boolean visibleThroughFog, System.Boolean scaleSizeWithZoom, System.Int32 facing) [0x0006c] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.Mods.Common.Widgets.WorldInteractionControllerWidget+<ApplyOrders>c__AnonStorey1.<>m__0 (OpenRA.World w) [0x00000] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.World.Tick () [0x00154] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.InnerLogicTick (OpenRA.Network.OrderManager orderManager) [0x0021a] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.LogicTick () [0x00050] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.Loop () [0x000d6] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.Run () [0x00042] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Program.Run (System.String[] args) [0x00011] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Program.Main (System.String[] args) [0x0004f] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
```

Crash when placing a Windtrap:

```
Exception of type `System.InvalidOperationException`: Unit `overlay` does not have a sequence named `build-valid-dune2`
  at OpenRA.Graphics.SequenceProvider.GetSequence (System.String unitName, System.String sequenceName) [0x0005e] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Mods.Common.Orders.PlaceBuildingOrderGenerator..ctor (OpenRA.Mods.Common.Traits.ProductionQueue queue, System.String name) [0x00116] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.Mods.Common.Widgets.ProductionPaletteWidget.PickUpCompletedBuildingIcon (OpenRA.Mods.Common.Widgets.ProductionIcon icon, OpenRA.Mods.Common.Traits.ProductionItem item) [0x0004b] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.Mods.Common.Widgets.ProductionPaletteWidget.HandleLeftClick (OpenRA.Mods.Common.Traits.ProductionItem item, OpenRA.Mods.Common.Widgets.ProductionIcon icon, System.Int32 handleCount) [0x0000e] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.Mods.Common.Widgets.ProductionPaletteWidget.HandleEvent (OpenRA.Mods.Common.Widgets.ProductionIcon icon, OpenRA.MouseButton btn, OpenRA.Modifiers modifiers) [0x00046] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.Mods.Common.Widgets.ProductionPaletteWidget.HandleMouseInput (OpenRA.MouseInput mi) [0x00089] in <0adcd370f496454ca37b409bd9609ccb>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x000cc] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x00063] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x00063] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x00063] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x00063] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x00063] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (OpenRA.MouseInput mi) [0x00063] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Widgets.Ui.HandleInput (OpenRA.MouseInput mi) [0x0003e] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.DefaultInputHandler+<OnMouseInput>c__AnonStorey2.<>m__0 () [0x00000] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Sync.CheckSyncUnchanged[T] (OpenRA.World world, System.Func`1[TResult] fn) [0x00043] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.DefaultInputHandler.OnMouseInput (OpenRA.MouseInput input) [0x0000e] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Platforms.Default.Sdl2Input.PumpInput (OpenRA.IInputHandler inputHandler) [0x00157] in <5794925004a44fb4954044de2d81fa74>:0 
  at OpenRA.Platforms.Default.Sdl2GraphicsDevice.PumpInput (OpenRA.IInputHandler inputHandler) [0x00007] in <5794925004a44fb4954044de2d81fa74>:0 
  at OpenRA.Renderer.EndFrame (OpenRA.IInputHandler inputHandler) [0x0000d] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.RenderTick () [0x00142] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.Loop () [0x00142] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Game.Run () [0x00042] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Program.Run (System.String[] args) [0x00011] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
  at OpenRA.Program.Main (System.String[] args) [0x0004f] in <489f6a6d5c2648b9abc4da34f5d49db6>:0 
```