### PR TITLE
Update concrete.yaml to fix base-expanding

### DIFF
--- a/rules/concrete.yaml
+++ b/rules/concrete.yaml
@@ -4,7 +4,7 @@
 		TerrainTypes: Rock
 		BuildSounds: CHUNG.WAV
 		AllowInvalidPlacement: true
-		Adjacent: 1
+		Adjacent: 3
 	GivesBuildableArea:
 	Tooltip:
 		Name: Concrete


### PR DESCRIPTION
this will fix the issue of single and quad-concrete only being allowed to get placed one time around the conyard , thus making expanding not possible ...  as discussed in #9

the idea here is to allow concrete to get placed in a 3-cell range around a placed building ... but still only allow buildings to get placed one after another 

though it is not the "original" concrete & building placement (endless one by one and buildings can get attached to it) it does add a more "dune-ish" way of expanding while keep basecreeping at a minimum (noticeable on the AI - behaviour)