### PR TITLE
Remove WithNukeLaunchOverlay from palace

### DIFF
--- a/mods/d2/rules/palace.yaml
+++ b/mods/d2/rules/palace.yaml
@@ -76,11 +76,6 @@ palace:
 		CameraRange: 10c0
 		ArrowSequence: arrow
 		CircleSequence: circles
-	WithNukeLaunchOverlay:
-		RequiresCondition: !launchpad-damaged && harkonnen
-	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
-		Condition: launchpad-damaged
-		ValidDamageState: Medium, Heavy, Critical
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility


### PR DESCRIPTION
D2 doesn't have a anim for palace firing the Death Hand, so existence of this trait causing crash saying Palace doesn't have a sequence named active.