### PR TITLE
Update prerequisites of structures and infantry

### DIFF
--- a/mods/d2/rules/barracks.yaml
+++ b/mods/d2/rules/barracks.yaml
@@ -1,9 +1,9 @@
 barracks:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, wind_trap
+		Prerequisites: ~structure.atreides_or_ordos, wind_trap, outpost
 		Queue: Building
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 100
 		BuildDuration: 900
 		BuildDurationModifier: 40
 		Description: Trains infantry
@@ -59,6 +59,8 @@ barracks:
 	WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	ProvidesPrerequisite@buildingname:
+	ProvidesPrerequisite@har_conyard_or_barracks:
+		Prerequisite: har_conyard_or_barracks
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.barracks
 		Condition: stardecoration

--- a/mods/d2/rules/concrete.yaml
+++ b/mods/d2/rules/concrete.yaml
@@ -53,7 +53,7 @@ concreteb:
 	Valued:
 		Cost: 20
 	Buildable:
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 40
 		BuildDuration: 200
 		BuildDurationModifier: 40
 		Prerequisites: upgrade.conyard

--- a/mods/d2/rules/construction_yard.yaml
+++ b/mods/d2/rules/construction_yard.yaml
@@ -47,6 +47,24 @@ construction_yard:
 		PrimaryCondition: primary
 		ProductionQueues: Building
 	ProvidesPrerequisite@buildingname:
+	ProvidesPrerequisite@Atreides:
+		Prerequisite: structure.atreides
+		Factions: atreides
+	ProvidesPrerequisite@Ordos:
+		Prerequisite: structure.ordos
+		Factions: ordos
+	ProvidesPrerequisite@Harkonnen:
+		Prerequisite: structure.harkonnen
+		Factions: harkonnen
+	ProvidesPrerequisite@Atreides+Ordos:
+		Prerequisite: structure.atreides_or_ordos
+		Factions: atreides, ordos
+	ProvidesPrerequisite@Ordos+Harkonnen:
+		Prerequisite: structure.ordos_or_harkonnen
+		Factions: ordos, harkonnen
+	ProvidesPrerequisite@har_conyard_or_barracks:
+		Prerequisite: har_conyard_or_barracks
+		Factions: harkonnen
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.conyard
 		Condition: stardecoration

--- a/mods/d2/rules/gun_turret.yaml
+++ b/mods/d2/rules/gun_turret.yaml
@@ -3,8 +3,8 @@ gun_turret:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, barracks
-		BuildPaletteOrder: 90
+		Prerequisites: wind_trap, outpost
+		BuildPaletteOrder: 80
 		BuildDuration: 800
 		BuildDurationModifier: 40
 		Description: Defensive structure\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft

--- a/mods/d2/rules/heavy_factory.yaml
+++ b/mods/d2/rules/heavy_factory.yaml
@@ -1,9 +1,9 @@
 heavy_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, refinery
+		Prerequisites: wind_trap, light_factory, outpost
 		Queue: Building
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 130
 		BuildDuration: 1800
 		BuildDurationModifier: 40
 		Description: Produces heavy vehicles

--- a/mods/d2/rules/high_tech_factory.yaml
+++ b/mods/d2/rules/high_tech_factory.yaml
@@ -1,9 +1,9 @@
 high_tech_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, outpost, ~techlevel.medium
+		Prerequisites: wind_trap, light_factory, outpost, ~techlevel.medium
 		Queue: Building
-		BuildPaletteOrder: 110
+		BuildPaletteOrder: 140
 		BuildDuration: 1500
 		BuildDurationModifier: 40
 		Description: Unlocks advanced technology

--- a/mods/d2/rules/light_factory.yaml
+++ b/mods/d2/rules/light_factory.yaml
@@ -1,9 +1,9 @@
 light_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, refinery
+		Prerequisites: wind_trap, refinery
 		Queue: Building
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 110
 		BuildDuration: 1200
 		BuildDurationModifier: 40
 		Description: Produces light vehicles

--- a/mods/d2/rules/light_inf.yaml
+++ b/mods/d2/rules/light_inf.yaml
@@ -6,6 +6,7 @@ light_inf:
 		BuildPaletteOrder: 10
 		BuildDuration: 400
 		BuildDurationModifier: 40
+		Prerequisites: ~barracks
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Valued:
 		Cost: 60

--- a/mods/d2/rules/light_squad.yaml
+++ b/mods/d2/rules/light_squad.yaml
@@ -6,7 +6,7 @@ light_squad:
 		BuildPaletteOrder: 10
 		BuildDuration: 400
 		BuildDurationModifier: 40
-		Prerequisites: upgrade.barracks
+		Prerequisites: ~barracks, upgrade.barracks, ~techlevel.medium
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Valued:
 		Cost: 100

--- a/mods/d2/rules/outpost.yaml
+++ b/mods/d2/rules/outpost.yaml
@@ -2,7 +2,7 @@ outpost:
 	Inherits: ^Building
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Buildable:
-		Prerequisites: construction_yard, barracks, ~techlevel.medium
+		Prerequisites: wind_trap
 		Queue: Building
 		BuildPaletteOrder: 50
 		BuildDuration: 1000

--- a/mods/d2/rules/palace.yaml
+++ b/mods/d2/rules/palace.yaml
@@ -2,9 +2,9 @@ palace:
 	Inherits: ^Building
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Buildable:
-		Prerequisites: construction_yard, research_centre, ~techlevel.high
+		Prerequisites: starport, ~techlevel.high
 		Queue: Building
-		BuildPaletteOrder: 150
+		BuildPaletteOrder: 170
 		BuildDuration: 1620
 		BuildDurationModifier: 40
 		Description: Unlocks elite infantry and weapons

--- a/mods/d2/rules/refinery.yaml
+++ b/mods/d2/rules/refinery.yaml
@@ -1,9 +1,9 @@
 refinery:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, wind_trap
+		Prerequisites: wind_trap
 		Queue: Building
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 30
 		BuildDuration: 1000
 		BuildDurationModifier: 40
 		Description: Harvesters unload Spice here for processing

--- a/mods/d2/rules/repair_pad.yaml
+++ b/mods/d2/rules/repair_pad.yaml
@@ -2,8 +2,8 @@ repair_pad:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, heavy_factory, upgrade.heavy, ~techlevel.medium
-		BuildPaletteOrder: 130
+		Prerequisites: light_factory, wind_trap, outpost, ~techlevel.medium
+		BuildPaletteOrder: 160
 		BuildDuration: 1000
 		BuildDurationModifier: 40
 		Description: Repairs vehicles\n Allows construction of MCVs

--- a/mods/d2/rules/research_centre.yaml
+++ b/mods/d2/rules/research_centre.yaml
@@ -2,8 +2,8 @@ research_centre:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, outpost, heavy_factory, upgrade.heavy, ~techlevel.high
-		BuildPaletteOrder: 140
+		Prerequisites: wind_trap, starport, refinery, ~techlevel.high
+		BuildPaletteOrder: 150
 		BuildDuration: 1500
 		BuildDurationModifier: 40
 		Description: Unlocks experimental tanks

--- a/mods/d2/rules/rocket_turret.yaml
+++ b/mods/d2/rules/rocket_turret.yaml
@@ -6,8 +6,8 @@ rocket_turret:
 		PauseOnCondition: disabled
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, outpost, upgrade.conyard, ~techlevel.medium
-		BuildPaletteOrder: 120
+		Prerequisites: wind_trap, outpost, upgrade.conyard, ~techlevel.medium
+		BuildPaletteOrder: 90
 		BuildDuration: 1200
 		BuildDurationModifier: 40
 		Description: Defensive structure\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate

--- a/mods/d2/rules/silo.yaml
+++ b/mods/d2/rules/silo.yaml
@@ -1,9 +1,9 @@
 silo:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, refinery
+		Prerequisites: wind_trap, refinery
 		Queue: Building
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 60
 		BuildDuration: 600
 		BuildDurationModifier: 40
 		Description: Stores excess harvested Spice

--- a/mods/d2/rules/starport.yaml
+++ b/mods/d2/rules/starport.yaml
@@ -3,9 +3,9 @@ starport:
 	Tooltip:
 		Name: Starport
 	Buildable:
-		Prerequisites: construction_yard, heavy_factory, outpost, ~techlevel.high
+		Prerequisites: wind_trap, refinery, ~techlevel.high
 		Queue: Building
-		BuildPaletteOrder: 80
+		BuildPaletteOrder: 120
 		BuildDuration: 1500
 		BuildDurationModifier: 40
 		Description: Dropzone for quick reinforcements, at a price.\n  Requires power to operate

--- a/mods/d2/rules/trooper.yaml
+++ b/mods/d2/rules/trooper.yaml
@@ -6,7 +6,7 @@ trooper:
 		BuildPaletteOrder: 20
 		BuildDuration: 700
 		BuildDurationModifier: 40
-		Prerequisites: wor, ~techlevel.medium
+		Prerequisites: ~wor
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
 	Valued:
 		Cost: 100

--- a/mods/d2/rules/trooper_squad.yaml
+++ b/mods/d2/rules/trooper_squad.yaml
@@ -6,7 +6,7 @@ trooper_squad:
 		BuildPaletteOrder: 20
 		BuildDuration: 700
 		BuildDurationModifier: 40
-		Prerequisites: wor, upgrade.wor, ~techlevel.medium
+		Prerequisites: ~wor, upgrade.wor, ~techlevel.medium
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
 	Valued:
 		Cost: 200

--- a/mods/d2/rules/wall.yaml
+++ b/mods/d2/rules/wall.yaml
@@ -6,8 +6,8 @@ wall:
 	ScriptTriggers:
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, barracks
-		BuildPaletteOrder: 60
+		Prerequisites: wind_trap, outpost
+		BuildPaletteOrder: 70
 		BuildDuration: 500
 		BuildDurationModifier: 40
 		Description: Stop units and blocks enemy fire.

--- a/mods/d2/rules/wind_trap.yaml
+++ b/mods/d2/rules/wind_trap.yaml
@@ -2,8 +2,7 @@ wind_trap:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 20
 		BuildDuration: 600
 		BuildDurationModifier: 40
 		Description: Provides power for other structures

--- a/mods/d2/rules/wor.yaml
+++ b/mods/d2/rules/wor.yaml
@@ -1,9 +1,9 @@
 wor:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, wind_trap, barracks
+		Prerequisites: ~structure.ordos_or_harkonnen, wind_trap, har_conyard_or_barracks, outpost
 		Queue: Building
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 100
 		BuildDuration: 1300
 		BuildDurationModifier: 40
 		Description: Trains heavy infantry


### PR DESCRIPTION
Didn't touch the vehicles yet and i'm not sure if those are really correct, but i used what Nyerguds' D2 Editor says.

It says WOR's prereqs are Windtrap, Outpost, Barracks, but Harkonnen has no Barracks, so i think they should be getting it directly after outpost, ~~again i didn't check by playing original game.~~ Edit: I'm at 3rd Harkonnen mission, that appears to be the case.

I also edited the palette orders, but Ordos having both barracks and WOR isn't helping.