### PR TITLE
Change damage values to original and remove Versus:

### DIFF
--- a/mods/d2/rules/combat_tank.yaml
+++ b/mods/d2/rules/combat_tank.yaml
@@ -1,4 +1,4 @@
-^combat_tank:
+combat_tank:
 	Inherits: ^Tank
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -6,13 +6,14 @@
 		BuildPaletteOrder: 40
 		BuildDuration: 800
 		BuildDurationModifier: 40
-		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n \n  Atreides:      +Range\n  Harkonnen: +Health\n  Ordos:         +Speed
+		Prerequisites: heavy_factory
+		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n
 	Valued:
 		Cost: 300
 	Tooltip:
 		Name: Combat Tank
 	Health:
-		HP: 21000
+		HP: 200
 	Armor:
 		Type: heavy
 	Mobile:
@@ -25,7 +26,7 @@
 		TurnSpeed: 5
 		RealignDelay: 0
 	Armament:
-		Weapon: 80mm_A
+		Weapon: 80mm
 		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
@@ -42,42 +43,6 @@
 	AttractsWorms:
 		Intensity: 520
 	SpawnActorOnDeath:
+		Actor: combat_tank.husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
-
-combat_tank_a:
-	Inherits: ^combat_tank
-	Buildable:
-		Prerequisites: ~heavy.atreides_combat
-	Armament:
-		Weapon: 80mm_A
-	SpawnActorOnDeath:
-		Actor: combat_tank_a.husk
-
-combat_tank_h:
-	Inherits: ^combat_tank
-	Buildable:
-		Prerequisites: ~heavy.harkonnen_combat
-	Armament:
-		Weapon: 80mm_H
-	Mobile:
-		Speed: 64
-	Health:
-		HP: 27000
-	SpawnActorOnDeath:
-		Actor: combat_tank_h.husk
-
-combat_tank_o:
-	Inherits: ^combat_tank
-	Buildable:
-		Prerequisites: ~heavy.ordos_combat
-	Turreted:
-		TurnSpeed: 5
-	Armament:
-		Weapon: 80mm_O
-	Mobile:
-		Speed: 85
-	Health:
-		HP: 18000
-	SpawnActorOnDeath:
-		Actor: combat_tank_o.husk

--- a/mods/d2/rules/husks.yaml
+++ b/mods/d2/rules/husks.yaml
@@ -43,24 +43,11 @@ deviator.husk:
 	TransformOnCapture:
 		IntoActor: deviator
 
-^combat_tank.husk:
+combat_tank.husk:
 	Inherits: ^VehicleHusk
 	Health:
 		HP: 100
 	ThrowsParticle@turret:
 		Anim: turret
-
-combat_tank_a.husk:
-	Inherits: ^combat_tank.husk
 	TransformOnCapture:
-		IntoActor: combat_tank_a
-
-combat_tank_h.husk:
-	Inherits: ^combat_tank.husk
-	TransformOnCapture:
-		IntoActor: combat_tank_h
-
-combat_tank_o.husk:
-	Inherits: ^combat_tank.husk
-	TransformOnCapture:
-		IntoActor: combat_tank_o
+		IntoActor: combat_tank

--- a/mods/d2/rules/raider.yaml
+++ b/mods/d2/rules/raider.yaml
@@ -24,10 +24,10 @@ raider:
 		MovingRange: 1c256
 	WithMuzzleOverlay:
 	Armament@damage:
-		Weapon: HMGo
+		Weapon: HMG
 		LocalOffset: 170,0,0
 	Armament@muzzle:
-		Weapon: HMGo_muzzle
+		Weapon: HMG_muzzle
 		LocalOffset: 170,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:

--- a/mods/d2/rules/starport_items.yaml
+++ b/mods/d2/rules/starport_items.yaml
@@ -58,35 +58,15 @@ missile_tank.starport:
 	RenderSprites:
 		Image: missile_tank
 
-combat_tank_a.starport:
-	Inherits: combat_tank_a
+combat_tank.starport:
+	Inherits: combat_tank
 	Buildable:
-		Prerequisites: ~starport.atreides
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 1300
 	RenderSprites:
-		Image: combat_tank_a
-
-combat_tank_h.starport:
-	Inherits: combat_tank_h
-	Buildable:
-		Prerequisites: ~starport.harkonnen
-		Queue: Starport
-	Valued:
-		Cost: 1300
-	RenderSprites:
-		Image: combat_tank_h
-
-combat_tank_o.starport:
-	Inherits: combat_tank_o
-	Buildable:
-		Prerequisites: ~starport.ordos
-		Queue: Starport
-	Valued:
-		Cost: 1300
-	RenderSprites:
-		Image: combat_tank_o
+		Image: combat_tank
 
 carryall.starport:
 	Inherits: carryall

--- a/mods/d2/weapons/largeguns.yaml
+++ b/mods/d2/weapons/largeguns.yaml
@@ -11,16 +11,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 290
-		Versus:
-			none: 20
-			wall: 50
-			building: 50
-			wood: 60
-			heavy: 75
-			invulnerable: 0
-			cy: 20
-			harvester: 50
+		Damage: 20
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -28,7 +19,7 @@
 		Explosions: small_napalm
 		ImpactSounds: EXPLSML4.WAV
 
-80mm_A:
+80mm:
 	ReloadDelay: 50
 	Range: 4c0
 	Report: MEDTANK1.WAV
@@ -39,70 +30,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 270
-		Versus:
-			none: 20
-			wall: 50
-			building: 50
-			wood: 60
-			heavy: 75
-			invulnerable: 0
-			cy: 20
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-	Warhead@3Eff: CreateEffect
-		Explosions: small_napalm
-
-80mm_H:
-	ReloadDelay: 55
-	Range: 4c0
-	Report: MEDTANK1.WAV
-	Projectile: Bullet
-		Speed: 562
-		Inaccuracy: 380
-		Image: 120mm
-	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
-		Damage: 270
-		Versus:
-			none: 20
-			wall: 50
-			building: 50
-			wood: 60
-			heavy: 75
-			invulnerable: 0
-			cy: 20
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-	Warhead@3Eff: CreateEffect
-		Explosions: small_napalm
-
-80mm_O:
-	ReloadDelay: 45
-	Range: 4c0
-	Report: MEDTANK1.WAV
-	Projectile: Bullet
-		Speed: 562
-		Inaccuracy: 380
-		Image: 120mm
-	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
-		Damage: 270
-		Versus:
-			none: 20
-			wall: 50
-			building: 50
-			wood: 60
-			heavy: 75
-			invulnerable: 0
-			cy: 20
-			harvester: 50
+		Damage: 25
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -120,13 +48,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Falloff: 100, 50, 25, 0
-		Damage: 650
-		Versus:
-			none: 50
-			building: 75
-			wood: 60
-			invulnerable: 0
-			cy: 40
+		Damage: 30
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -149,15 +71,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 416
 		Falloff: 100, 65, 35, 20, 0
-		Damage: 450
-		Versus:
-			none: 125
-			wood: 70
-			light: 30
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
+		Damage: 40
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater

--- a/mods/d2/weapons/missiles.yaml
+++ b/mods/d2/weapons/missiles.yaml
@@ -14,16 +14,7 @@ Bazooka:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
-		Damage: 300
-		Versus:
-			none: 8
-			wall: 75
-			building: 40
-			wood: 45
-			light: 70
-			invulnerable: 0
-			cy: 20
-			harvester: 50
+		Damage: 5
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -47,15 +38,7 @@ Rocket:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 50, 25, 0
-		Damage: 250
-		Versus:
-			none: 25
-			building: 50
-			wood: 65
-			heavy: 50
-			invulnerable: 0
-			cy: 20
-			harvester: 50
+		Damage: 7
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -88,17 +71,8 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 480
+		Damage: 30
 		ValidTargets: Ground, Air
-		Versus:
-			none: 15
-			wall: 75
-			building: 60
-			wood: 65
-			light: 90
-			invulnerable: 0
-			cy: 30
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -129,17 +103,8 @@ mtank_pri:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 600
+		Damage: 75
 		ValidTargets: Ground, Air
-		Versus:
-			none: 15
-			wall: 75
-			building: 60
-			wood: 65
-			light: 90
-			invulnerable: 0
-			cy: 30
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -166,23 +131,6 @@ DeviatorMissile:
 		#TrailPalette: deviatorgas
 		#TrailUsePlayerPalette: true
 		#TrailInterval: 1
-	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
-		Damage: 500
-		Versus:
-			none: 20
-			wall: 20
-			building: 20
-			wood: 20
-			light: 20
-			heavy: 20
-			invulnerable: 0
-			cy: 10
-			harvester: 20
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosions: deviator
 		ExplosionPalette: deviatorgas

--- a/mods/d2/weapons/other.yaml
+++ b/mods/d2/weapons/other.yaml
@@ -15,31 +15,17 @@ Sound:
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 150
+		Damage: 60
 		AffectsParent: false
 		ValidStances: Neutral, Enemy
-		Versus:
-			wall: 50
-			building: 60
-			heavy: 60
-			invulnerable: 0
-			cy: 20
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 50, 50 # Only does half damage to friendly units
-		Damage: 150
+		Damage: 60
 		InvalidTargets: Sonictank # Does not affect friendly sonic tanks at all
 		AffectsParent: false
 		ValidStances: Ally
-		Versus:
-			wall: 50
-			building: 60
-			heavy: 60
-			invulnerable: 0
-			cy: 20
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 
 Heal:
@@ -77,17 +63,7 @@ OrniBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 1000 #400 in original, reduce when bombers can do multiple passes
-		Versus:
-			none: 90
-			wall: 50
-			building: 75
-			wood: 60
-			light: 60
-			heavy: 60
-			invulnerable: 0
-			cy: 25
-			harvester: 60
+		Damage: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -113,17 +89,7 @@ Atomic:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
 		Falloff: 200, 100, 50, 25, 12, 0
-		Damage: 2700	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
-		Versus:
-			none: 90
-			wall: 50
-			building: 75
-			wood: 60
-			light: 60
-			heavy: 60
-			invulnerable: 0
-			cy: 25
-			harvester: 60
+		Damage: 100
 		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: nuke
@@ -133,17 +99,7 @@ CrateNuke:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 500
-		Versus:
-			none: 90
-			wall: 50
-			building: 75
-			wood: 60
-			light: 60
-			heavy: 60
-			invulnerable: 0
-			cy: 25
-			harvester: 60
+		Damage: 100
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Eff: CreateEffect
@@ -154,17 +110,7 @@ CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 500
-		Versus:
-			none: 90
-			wall: 5
-			building: 65
-			wood: 50
-			light: 40
-			heavy: 30
-			invulnerable: 0
-			cy: 20
-			harvester: 25
+		Damage: 100
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
@@ -207,15 +153,6 @@ SardDeath:
 		Spread: 256
 		Falloff: 100, 50, 25, 0
 		Damage: 300
-		Versus:
-			none: 15
-			wall: 75
-			building: 60
-			wood: 65
-			light: 90
-			invulnerable: 0
-			cy: 30
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater

--- a/mods/d2/weapons/smallguns.yaml
+++ b/mods/d2/weapons/smallguns.yaml
@@ -7,16 +7,7 @@ LMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
-		Damage: 125
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
+		Damage: 3
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -31,15 +22,6 @@ Fremen_S:
 		Spread: 128
 		Falloff: 100, 50, 25, 0
 		Damage: 125
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
@@ -55,15 +37,6 @@ M_LMG:
 		Spread: 128
 		Falloff: 100, 50, 25, 0
 		Damage: 125
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -78,14 +51,6 @@ M_HMG:
 		Spread: 192
 		Falloff: 100, 50, 25, 0
 		Damage: 250
-		Versus:
-			none: 25
-			building: 50
-			wood: 65
-			heavy: 50
-			invulnerable: 0
-			cy: 20
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -101,14 +66,6 @@ Fremen_L:
 		Spread: 192
 		Falloff: 100, 50, 25, 0
 		Damage: 250
-		Versus:
-			none: 25
-			building: 50
-			wood: 65
-			heavy: 50
-			invulnerable: 0
-			cy: 20
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
@@ -122,52 +79,13 @@ HMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 60, 30, 0
-		Damage: 180
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
-		Explosions: piffs
-
-HMGo:
-	ReloadDelay: 18
-	Range: 3c0
-	Report: 20MMGUN1.WAV
-	Projectile: Bullet
-		Speed: 1c256
-	Warhead@1Dam: SpreadDamage
-		Spread: 160
-		Falloff: 100, 60, 30, 0
-		Damage: 180
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
+		Damage: 5
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
 
 HMG_muzzle:
 	ReloadDelay: 16
-	Range: 3c0
-	Burst: 3
-	BurstDelay: 2
-	Warhead@TargetValidation: SpreadDamage
-
-HMGo_muzzle:
-	ReloadDelay: 14
 	Range: 3c0
 	Burst: 3
 	BurstDelay: 2

--- a/mods/d2/weapons/spicebloom.yaml
+++ b/mods/d2/weapons/spicebloom.yaml
@@ -8,16 +8,6 @@ SpiceExplosion:
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
 		Damage: 75
-		Versus:
-			none: 90
-			wall: 5
-			building: 65
-			wood: 50
-			light: 40
-			heavy: 30
-			invulnerable: 0
-			cy: 20
-			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		AffectsParent: true
 	Warhead@2Res: CreateResource
@@ -37,16 +27,6 @@ BloomExplosion:
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
 		Damage: 750
-		Versus:
-			none: 90
-			wall: 5
-			building: 65
-			wood: 50
-			light: 40
-			heavy: 30
-			invulnerable: 0
-			cy: 20
-			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		AffectsParent: true
 

--- a/mods/d2/weapons/squads.yaml
+++ b/mods/d2/weapons/squads.yaml
@@ -14,16 +14,7 @@ Bazooka_squad:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
-		Damage: 300
-		Versus:
-			none: 8
-			wall: 75
-			building: 40
-			wood: 45
-			light: 70
-			invulnerable: 0
-			cy: 20
-			harvester: 50
+		Damage: 5
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -40,16 +31,7 @@ LMG_squad:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
-		Damage: 200
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
+		Damage: 3
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs


### PR DESCRIPTION
This also merges the combat tanks (there weren't seperate ones in D2) and trike/raider weapon (raider is only move faster not fire faster).

Original game didn't have armor classes, so i removed Versus values, tho not the Armor: traits yet.