### PR TITLE
Reorder lobby options so Worms go to place of Crates.

### DIFF
--- a/mods/d2/rules/player.yaml
+++ b/mods/d2/rules/player.yaml
@@ -63,7 +63,7 @@ Player:
 		DefaultCash: 1500
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
-		CheckboxDisplayOrder: 6
+		CheckboxDisplayOrder: 5
 	BaseAttackNotifier:
 	Shroud:
 		FogCheckboxDisplayOrder: 3

--- a/mods/d2/rules/world.yaml
+++ b/mods/d2/rules/world.yaml
@@ -92,7 +92,7 @@ World:
 	MapCreeps:
 		CheckboxLabel: Worms
 		CheckboxDescription: Worms roam the map and devour unprepared forces
-		CheckboxDisplayOrder: 5
+		CheckboxDisplayOrder: 1
 	SpawnMapActors:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxDisplayOrder: 4


### PR DESCRIPTION
D2 mod looks like lacking crates, which makes lobby order wierd. I put worms to place of crates, so locations of other options match other mods.