### PR TITLE
Make Sight Values match original

### DIFF
--- a/mods/d2/rules/combat_tank.yaml
+++ b/mods/d2/rules/combat_tank.yaml
@@ -20,8 +20,8 @@ combat_tank:
 		Speed: 75
 		TurnSpeed: 5
 	D2RevealsShroud:
-		Range: 3c256
-		MovingRange: 1c256
+		Range: 3c0
+		MovingRange: 1c768
 	Turreted:
 		TurnSpeed: 5
 		RealignDelay: 0

--- a/mods/d2/rules/construction_yard.yaml
+++ b/mods/d2/rules/construction_yard.yaml
@@ -20,7 +20,7 @@ construction_yard:
 	Armor:
 		Type: cy
 	RevealsShroud:
-		Range: 5c768
+		Range: 3c0
 	Production:
 		Produces: Building, Upgrade
 	Exit:

--- a/mods/d2/rules/devastator.yaml
+++ b/mods/d2/rules/devastator.yaml
@@ -24,8 +24,8 @@ devastator:
 	AutoCarryable:
 		RequiresCondition: !overload
 	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
+		Range: 4c0
+		MovingRange: 1c768
 	Armament:
 		Weapon: DevBullet
 		LocalOffset: 640,0,32

--- a/mods/d2/rules/deviator.yaml
+++ b/mods/d2/rules/deviator.yaml
@@ -21,7 +21,7 @@ deviator:
 		Type: wood
 	D2RevealsShroud:
 		Range: 4c768
-		MovingRange: 1c256
+		MovingRange: 1c768
 	Armament:
 		Weapon: DeviatorMissile
 		LocalOffset: -299,0,85

--- a/mods/d2/rules/fremen.yaml
+++ b/mods/d2/rules/fremen.yaml
@@ -14,9 +14,6 @@ fremen:
 		Cost: 200	## actually 0, but spawns from support power at Palace
 	Health:
 		HP: 700
-	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
 	AutoTarget:
 		ScanRadius: 7
 		InitialStance: HoldFire

--- a/mods/d2/rules/gun_turret.yaml
+++ b/mods/d2/rules/gun_turret.yaml
@@ -24,7 +24,7 @@ gun_turret:
 	Armor:
 		Type: heavy
 	RevealsShroud:
-		Range: 4c768
+		Range: 2c0
 	BodyOrientation:
 		QuantizedFacings: 8
 	WithMuzzleOverlay:

--- a/mods/d2/rules/harvester.yaml
+++ b/mods/d2/rules/harvester.yaml
@@ -31,8 +31,8 @@ harvester:
 		Speed: 43
 		Crushes: infantry, spicebloom
 	D2RevealsShroud:
-		Range: 3c768
-		MovingRange: 1c256
+		Range: 2c0
+		MovingRange: 1c768
 	Explodes:
 		Weapon: UnitExplodeLarge
 		EmptyWeapon: UnitExplodeLarge

--- a/mods/d2/rules/heavy_factory.yaml
+++ b/mods/d2/rules/heavy_factory.yaml
@@ -25,7 +25,7 @@ heavy_factory:
 	Armor:
 		Type: wood
 	RevealsShroud:
-		Range: 4c768
+		Range: 3c0
 	RallyPoint:
 		Offset: 0,3
 	Exit@1:

--- a/mods/d2/rules/high_tech_factory.yaml
+++ b/mods/d2/rules/high_tech_factory.yaml
@@ -34,7 +34,7 @@ high_tech_factory:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 4c768
+		Range: 3c0
 	WithTilesetBody:
 		SkipFrames: 3
 	WithIdleOverlay@FLAG:

--- a/mods/d2/rules/infantry.yaml
+++ b/mods/d2/rules/infantry.yaml
@@ -7,9 +7,8 @@
 	Health:
 	Armor:
 		Type: none
-	D2RevealsShroud:
+	RevealsShroud:
 		Range: 1c768
-		MovingRange: 1c256
 	Mobile:
 		Crushes: spicebloom
 		SharesCell: true

--- a/mods/d2/rules/light_factory.yaml
+++ b/mods/d2/rules/light_factory.yaml
@@ -25,7 +25,7 @@ light_factory:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 4c768
+		Range: 3c0
 	WithTilesetBody:
 		SkipFrames: 1
 	RenderSprites:

--- a/mods/d2/rules/mcv.yaml
+++ b/mods/d2/rules/mcv.yaml
@@ -22,8 +22,8 @@ mcv:
 		Speed: 31
 		Crushes: infantry, spicebloom
 	D2RevealsShroud:
-		Range: 2c768
-		MovingRange: 1c256
+		Range: 2c0
+		MovingRange: 1c768
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	BaseBuilding:

--- a/mods/d2/rules/missile_tank.yaml
+++ b/mods/d2/rules/missile_tank.yaml
@@ -20,8 +20,8 @@ missile_tank:
 	Armor:
 		Type: wood
 	D2RevealsShroud:
-		Range: 6c768
-		MovingRange: 1c256
+		Range: 4c768
+		MovingRange: 1c768
 	Armament:
 		Weapon: mtank_pri
 		LocalOffset: -128,128,171, -128,-128,171

--- a/mods/d2/rules/outpost.yaml
+++ b/mods/d2/rules/outpost.yaml
@@ -26,7 +26,7 @@ outpost:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 4c768
+		Range: 9c768
 	ProvidesRadar:
 		RequiresCondition: !disabled
 	WithTilesetBody:

--- a/mods/d2/rules/quad.yaml
+++ b/mods/d2/rules/quad.yaml
@@ -20,8 +20,8 @@ quad:
 		TurnSpeed: 8
 		Speed: 96
 	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
+		Range: 2c0
+		MovingRange: 1c768
 	Armament:
 		Weapon: Rocket
 		LocalOffset: 128,64,64, 128,-64,64

--- a/mods/d2/rules/raider.yaml
+++ b/mods/d2/rules/raider.yaml
@@ -20,8 +20,8 @@ raider:
 		TurnSpeed: 10
 		Speed: 149
 	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
+		Range: 2c0
+		MovingRange: 1c768
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMG

--- a/mods/d2/rules/refinery.yaml
+++ b/mods/d2/rules/refinery.yaml
@@ -25,7 +25,7 @@ refinery:
 	Armor:
 		Type: heavy
 	RevealsShroud:
-		Range: 4c768
+		Range: 4c0
 	Refinery:
 		DockAngle: 120
 		DockOffset: 2,1

--- a/mods/d2/rules/repair_pad.yaml
+++ b/mods/d2/rules/repair_pad.yaml
@@ -23,7 +23,7 @@ repair_pad:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 4c768
+		Range: 3c0
 	Selectable:
 		Bounds: 48,32
 	SelectionDecorations:

--- a/mods/d2/rules/research_centre.yaml
+++ b/mods/d2/rules/research_centre.yaml
@@ -25,7 +25,7 @@ research_centre:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 4c768
+		Range: 3c0
 	WithTilesetBody:
 		SkipFrames: 3
 	RenderSprites:

--- a/mods/d2/rules/sardaukar.yaml
+++ b/mods/d2/rules/sardaukar.yaml
@@ -16,9 +16,6 @@ sardaukar:
 		HP: 1000
 	Mobile:
 		Speed: 31
-	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 	Armament@PRIMARY:

--- a/mods/d2/rules/siege_tank.yaml
+++ b/mods/d2/rules/siege_tank.yaml
@@ -20,8 +20,8 @@ siege_tank:
 		Speed: 43
 		TurnSpeed: 3
 	D2RevealsShroud:
-		Range: 6c768
-		MovingRange: 1c256
+		Range: 4c0
+		MovingRange: 1c768
 	Turreted:
 		TurnSpeed: 3
 		Offset: 0,0,-32

--- a/mods/d2/rules/silo.yaml
+++ b/mods/d2/rules/silo.yaml
@@ -21,7 +21,7 @@ silo:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 2c768
+		Range: 2c0
 	WithTilesetBody:
 		SkipFrames: 1
 	RenderSprites:

--- a/mods/d2/rules/sonic_tank.yaml
+++ b/mods/d2/rules/sonic_tank.yaml
@@ -20,8 +20,8 @@ sonic_tank:
 		TurnSpeed: 3
 		Speed: 31
 	D2RevealsShroud:
-		Range: 5c768
-		MovingRange: 1c256
+		Range: 4c0
+		MovingRange: 1c768
 	Armament:
 		Weapon: Sound
 		LocalOffset: 600,0,427

--- a/mods/d2/rules/starport.yaml
+++ b/mods/d2/rules/starport.yaml
@@ -25,7 +25,7 @@ starport:
 	Armor:
 		Type: heavy
 	RevealsShroud:
-		Range: 4c768
+		Range: 5c768
 	RallyPoint:
 		Offset: 1,3
 	Exit@1:

--- a/mods/d2/rules/trike.yaml
+++ b/mods/d2/rules/trike.yaml
@@ -22,8 +22,8 @@ trike:
 		TurnSpeed: 10
 		Speed: 128
 	D2RevealsShroud:
-		Range: 3c512
-		MovingRange: 1c256
+		Range: 2c0
+		MovingRange: 1c768
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMG

--- a/mods/d2/rules/trooper.yaml
+++ b/mods/d2/rules/trooper.yaml
@@ -14,9 +14,6 @@ trooper:
 		Name: Trooper
 	Health:
 		HP: 45
-	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
 	Mobile:
 		Speed: 31
 	Armament:

--- a/mods/d2/rules/trooper_squad.yaml
+++ b/mods/d2/rules/trooper_squad.yaml
@@ -14,9 +14,6 @@ trooper_squad:
 		Name: Trooper
 	Health:
 		HP: 110
-	D2RevealsShroud:
-		Range: 4c768
-		MovingRange: 1c256
 	Mobile:
 		SharesCell: false
 		Speed: 31

--- a/mods/d2/rules/wall.yaml
+++ b/mods/d2/rules/wall.yaml
@@ -35,7 +35,7 @@ wall:
 	Armor:
 		Type: wall
 	RevealsShroud:
-		Range: 2c768
+		Range: 1c0
 	Crushable:
 		CrushClasses: wall
 	BlocksProjectiles:

--- a/mods/d2/rules/wind_trap.yaml
+++ b/mods/d2/rules/wind_trap.yaml
@@ -24,7 +24,7 @@ wind_trap:
 	Armor:
 		Type: building
 	RevealsShroud:
-		Range: 3c768
+		Range: 2c0
 	WithTilesetBody:
 		SkipFrames: 3
 	RenderSprites:

--- a/mods/d2/rules/wor.yaml
+++ b/mods/d2/rules/wor.yaml
@@ -25,7 +25,7 @@ wor:
 	Armor:
 		Type: wood
 	RevealsShroud:
-		Range: 3c768
+		Range: 3c0
 	RallyPoint:
 		Offset: 1,2
 	Exit@1:


### PR DESCRIPTION
5+ can't really match so i used something close. Original game and OpenRA appear to have different calculations. D2 ranges are way more circular.