### PR TITLE
Reorder lobby options to properly locate SeparateTeamSpawns

### DIFF
--- a/mods/d2/rules/player.yaml
+++ b/mods/d2/rules/player.yaml
@@ -70,7 +70,7 @@ Player:
 		DefaultCash: 1500
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
-		CheckboxDisplayOrder: 7
+		CheckboxDisplayOrder: 5
 	BaseAttackNotifier:
 	Shroud:
 		FogCheckboxDisplayOrder: 3

--- a/mods/d2/rules/world.yaml
+++ b/mods/d2/rules/world.yaml
@@ -174,6 +174,7 @@ World:
 		GameSpeedDropdownDisplayOrder: 3
 	CreateMPPlayers:
 	MPStartLocations:
+		SeparateTeamSpawnsCheckboxDisplayOrder: 6
 	MPStartUnits@conyard:
 		Class: none
 		ClassName: Con. Yard Only


### PR DESCRIPTION
New checkbox added with the new release, DisplayOrder wasn't set with the update so it was showing at the second place.