### PR TITLE
Implement Multi Queue logic.

### DIFF
--- a/mods/d2/chrome/ingame-player.yaml
+++ b/mods/d2/chrome/ingame-player.yaml
@@ -477,112 +477,7 @@ Container@PLAYER_WIDGETS:
 					Width: 25
 					Height: 274
 					Children:
-						ProductionTypeButton@BUILDING:
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Buildings
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Building
-							Key: ProductionTypeBuilding
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
-						ProductionTypeButton@INFANTRY:
-							Y: 62
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Infantry
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Infantry
-							Key: ProductionTypeInfantry
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
-						ProductionTypeButton@VEHICLE:
-							Y: 93
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Light Vehicles
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Vehicle
-							Key: ProductionTypeVehicle
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
-						ProductionTypeButton@TANKS:
-							Y: 124
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Heavy Vehicles
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Armor
-							Key: ProductionTypeTank
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
-						ProductionTypeButton@AIRCRAFT:
-							Y: 155
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Aircraft
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Aircraft
-							Key: ProductionTypeAircraft
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
-						ProductionTypeButton@STARPORT:
-							Y: 186
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Starport
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Starport
-							Key: ProductionTypeMerchant
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
-						ProductionTypeButton@UPGRADE: # Upgrade is defined after others so it won't be automatically selected after sell or at game start.
-							Y: 31
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Upgrades
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Upgrade
-							Key: ProductionTypeUpgrade
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
 						Button@SCROLL_UP_BUTTON:
-							Y: 217
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -596,7 +491,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: scrollbar
 									ImageName: up_arrow
 						Button@SCROLL_DOWN_BUTTON:
-							Y: 248
+							Y: 29
 							Width: 25
 							Height: 25
 							VisualHeight: 0

--- a/mods/d2/rules/barracks.yaml
+++ b/mods/d2/rules/barracks.yaml
@@ -36,10 +36,14 @@ barracks:
 		ExitCell: 1,2
 	Production:
 		Produces: Infantry
-	PrimaryBuilding:
-		PrimaryCondition: primary
-		ProductionQueues: Infantry
 	ProductionBar:
+		ProductionType: Infantry
+	ProductionQueue:
+		Type: Infantry
+		Group: Infantry
+		LowPowerSlowdown: 3
+		BlockedAudio: NoRoom
+		BuildDurationModifier: 250
 	ProvidesPrerequisite@atreides:
 		Prerequisite: barracks.atreides
 		Factions: atreides
@@ -74,9 +78,8 @@ upgrade.barracks:
 	Tooltip:
 		Name: Barracks Upgrade
 	Buildable:
-		BuildPaletteOrder: 20
-		Prerequisites: barracks
-		Queue: Upgrade
+		BuildPaletteOrder: 999
+		Queue: Infantry
 		BuildLimit: 1
 		BuildDuration: 250
 		BuildDurationModifier: 40

--- a/mods/d2/rules/construction_yard.yaml
+++ b/mods/d2/rules/construction_yard.yaml
@@ -22,14 +22,22 @@ construction_yard:
 	RevealsShroud:
 		Range: 5c768
 	Production:
-		Produces: Building, Upgrade
+		Produces: Building
+	ProductionBar:
+		ProductionType: Building
+	ProductionQueue:
+		Type: Building
+		Group: Building
+		LowPowerSlowdown: 3
+		QueuedAudio: Building
+		ReadyAudio: BuildingReady
+		BuildDurationModifier: 250
 	Exit:
 	Valued:
 		Cost: 400
 	Tooltip:
 		Name: Construction Yard
 	BaseBuilding:
-	ProductionBar:
 	Power:
 		Amount: 0
 	WithTilesetBody:
@@ -39,9 +47,6 @@ construction_yard:
 		PlayerPalette: player
 	WithIdleOverlay@FLAG:
 		Sequence: idle-flag
-	PrimaryBuilding:
-		PrimaryCondition: primary
-		ProductionQueues: Building
 	ProvidesPrerequisite@buildingname:
 	ProvidesPrerequisite@Atreides:
 		Prerequisite: structure.atreides
@@ -74,9 +79,8 @@ upgrade.conyard:
 	Tooltip:
 		Name: Construction Yard Upgrade
 	Buildable:
-		BuildPaletteOrder: 10
-		Prerequisites: construction_yard
-		Queue: Upgrade
+		BuildPaletteOrder: 999
+		Queue: Building
 		BuildLimit: 1
 		BuildDuration: 250
 		BuildDurationModifier: 40

--- a/mods/d2/rules/heavy_factory.yaml
+++ b/mods/d2/rules/heavy_factory.yaml
@@ -33,9 +33,14 @@ heavy_factory:
 		ExitCell: 0,2
 	Production:
 		Produces: Armor
-	PrimaryBuilding:
-		PrimaryCondition: primary
 	ProductionBar:
+		ProductionType: Armor
+	ProductionQueue:
+		Type: Armor
+		Group: Armor
+		LowPowerSlowdown: 3
+		BlockedAudio: NoRoom
+		BuildDurationModifier: 250
 	ProvidesPrerequisite@atreides:
 		Prerequisite: heavy.atreides
 		Factions: atreides
@@ -66,12 +71,6 @@ heavy_factory:
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.heavy
 		Condition: stardecoration
-	WithTextDecoration@primary:
-		RequiresSelection: true
-		Text: PRIMARY
-		ReferencePoint: Top
-		ZOffset: 256
-		RequiresCondition: primary
 
 upgrade.heavy:
 	AlwaysVisible:
@@ -79,9 +78,8 @@ upgrade.heavy:
 	Tooltip:
 		Name: Heavy Factory Upgrade
 	Buildable:
-		BuildPaletteOrder: 50
-		Prerequisites: heavy_factory
-		Queue: Upgrade
+		BuildPaletteOrder: 999
+		Queue: Armor
 		BuildLimit: 1
 		BuildDuration: 250
 		BuildDurationModifier: 40

--- a/mods/d2/rules/high_tech_factory.yaml
+++ b/mods/d2/rules/high_tech_factory.yaml
@@ -14,11 +14,15 @@ high_tech_factory:
 	Tooltip:
 		Name: High Tech Factory
 	ProductionFromMapEdge:
-		Produces: Aircraft, Upgrade
+		Produces: Aircraft
 	ProductionBar:
-	PrimaryBuilding:
-		PrimaryCondition: primary
-		ProductionQueues: Aircraft
+		ProductionType: Aircraft
+	ProductionQueue:
+		Type: Aircraft
+		Group: Aircraft
+		LowPowerSlowdown: 3
+		BlockedAudio: NoRoom
+		BuildDurationModifier: 312
 	Exit:
 		SpawnOffset: 0,0,728
 		ExitCell: 0,0
@@ -53,12 +57,6 @@ high_tech_factory:
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.hightech
 		Condition: stardecoration
-	WithTextDecoration@primary:
-		RequiresSelection: true
-		Text: PRIMARY
-		ReferencePoint: Top
-		ZOffset: 256
-		RequiresCondition: primary
 
 upgrade.hightech:
 	AlwaysVisible:
@@ -67,9 +65,9 @@ upgrade.hightech:
 	Tooltip:
 		Name: High Tech Factory Upgrade
 	Buildable:
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 999
 		Prerequisites: ~aircraft.atreides_or_ordos, ~techlevel.high
-		Queue: Upgrade
+		Queue: Aircraft
 		BuildLimit: 1
 		BuildDuration: 250
 		BuildDurationModifier: 40

--- a/mods/d2/rules/light_factory.yaml
+++ b/mods/d2/rules/light_factory.yaml
@@ -41,11 +41,15 @@ light_factory:
 		SpawnOffset: -244,224,0
 		ExitCell: 1,2
 	Production:
-		Produces: Vehicle, Upgrade
-	PrimaryBuilding:
-		PrimaryCondition: primary
-		ProductionQueues: Vehicle
+		Produces: Vehicle
 	ProductionBar:
+		ProductionType: Vehicle
+	ProductionQueue:
+		Type: Vehicle
+		Group: Vehicle
+		LowPowerSlowdown: 3
+		BlockedAudio: NoRoom
+		BuildDurationModifier: 250
 	ProvidesPrerequisite@atreides:
 		Prerequisite: light.atreides
 		Factions: atreides
@@ -67,12 +71,6 @@ light_factory:
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.light
 		Condition: stardecoration
-	WithTextDecoration@primary:
-		RequiresSelection: true
-		Text: PRIMARY
-		ReferencePoint: Top
-		ZOffset: 256
-		RequiresCondition: primary
 
 upgrade.light:
 	AlwaysVisible:
@@ -81,9 +79,9 @@ upgrade.light:
 	Tooltip:
 		Name: Light Factory Upgrade
 	Buildable:
-		BuildPaletteOrder: 40
-		Prerequisites: light.atreides_or_ordos
-		Queue: Upgrade
+		BuildPaletteOrder: 999
+		Prerequisites: ~light.atreides_or_ordos
+		Queue: Vehicle
 		BuildLimit: 1
 		BuildDuration: 250
 		BuildDurationModifier: 40

--- a/mods/d2/rules/light_inf.yaml
+++ b/mods/d2/rules/light_inf.yaml
@@ -6,7 +6,6 @@ light_inf:
 		BuildPaletteOrder: 10
 		BuildDuration: 400
 		BuildDurationModifier: 40
-		Prerequisites: ~barracks
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Valued:
 		Cost: 60

--- a/mods/d2/rules/light_squad.yaml
+++ b/mods/d2/rules/light_squad.yaml
@@ -6,7 +6,7 @@ light_squad:
 		BuildPaletteOrder: 10
 		BuildDuration: 400
 		BuildDurationModifier: 40
-		Prerequisites: ~barracks, upgrade.barracks, ~techlevel.medium
+		Prerequisites: upgrade.barracks, ~techlevel.medium
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Valued:
 		Cost: 100

--- a/mods/d2/rules/player.yaml
+++ b/mods/d2/rules/player.yaml
@@ -8,55 +8,6 @@ EditorPlayer:
 Player:
 	Inherits: ^BasePlayer
 	TechTree:
-	ClassicProductionQueue@Building:
-		Type: Building
-		BuildDurationModifier: 250
-		LowPowerSlowdown: 3
-		QueuedAudio: Building
-		ReadyAudio: BuildingReady
-		BlockedAudio: NoRoom
-		SpeedUp: true
-	ClassicProductionQueue@Infantry:
-		Type: Infantry
-		BuildDurationModifier: 250
-		LowPowerSlowdown: 3
-		BlockedAudio: NoRoom
-		SpeedUp: true
-	ClassicProductionQueue@Vehicle:
-		Type: Vehicle
-		BuildDurationModifier: 250
-		LowPowerSlowdown: 3
-		QueuedAudio: Building
-		BlockedAudio: NoRoom
-		SpeedUp: true
-	ClassicProductionQueue@Armor:
-		Type: Armor
-		BuildDurationModifier: 250
-		LowPowerSlowdown: 3
-		QueuedAudio: Building
-		BlockedAudio: NoRoom
-		SpeedUp: true
-	ClassicProductionQueue@Starport:
-		Type: Starport
-		BuildDurationModifier: 212
-		LowPowerSlowdown: 0
-		BlockedAudio: NoRoom
-		QueuedAudio: OrderPlaced
-		ReadyAudio:
-	ClassicProductionQueue@Aircraft:
-		Type: Aircraft
-		BuildDurationModifier: 312
-		LowPowerSlowdown: 3
-		QueuedAudio: Building
-		BlockedAudio: NoRoom
-		SpeedUp: true
-	ClassicProductionQueue@Upgrade:
-		Type: Upgrade
-		BuildDurationModifier: 250
-		LowPowerSlowdown: 1
-		QueuedAudio: Upgrading
-		ReadyAudio: NewOptions
-		BlockedAudio: NoRoom
 	PlaceBuilding:
 	SupportPowerManager:
 	ScriptTriggers:

--- a/mods/d2/rules/starport.yaml
+++ b/mods/d2/rules/starport.yaml
@@ -37,6 +37,14 @@ starport:
 	ProductionAirdrop:
 		Produces: Starport
 		ActorType: frigate
+	ProductionBar:
+		ProductionType: Starport
+	ProductionQueue:
+		Type: Starport
+		Group: Starport
+		LowPowerSlowdown: 1
+		BlockedAudio: NoRoom
+		BuildDurationModifier: 212
 	WithTilesetBody:
 		SkipFrames: 0
 	RenderSprites:
@@ -44,10 +52,6 @@ starport:
 		PlayerPalette: player
 	WithIdleOverlay@FLAG:
 		Sequence: idle-flag
-	ProductionBar:
-	PrimaryBuilding:
-		PrimaryCondition: primary
-		ProductionQueues: Starport
 	ProvidesPrerequisite@atreides:
 		Prerequisite: starport.atreides
 		Factions: atreides
@@ -69,9 +73,3 @@ starport:
 	Power:
 		Amount: -50
 	ProvidesPrerequisite@buildingname:
-	WithTextDecoration@primary:
-		RequiresSelection: true
-		Text: PRIMARY
-		ReferencePoint: Top
-		ZOffset: 256
-		RequiresCondition: primary

--- a/mods/d2/rules/trooper.yaml
+++ b/mods/d2/rules/trooper.yaml
@@ -2,11 +2,10 @@ trooper:
 	Inherits: ^Infantry
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
-		Queue: Infantry
+		Queue: Trooper
 		BuildPaletteOrder: 20
 		BuildDuration: 700
 		BuildDurationModifier: 40
-		Prerequisites: ~wor
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
 	Valued:
 		Cost: 100

--- a/mods/d2/rules/trooper_squad.yaml
+++ b/mods/d2/rules/trooper_squad.yaml
@@ -2,11 +2,11 @@ trooper_squad:
 	Inherits: ^Infantry_squad
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
-		Queue: Infantry
+		Queue: Trooper
 		BuildPaletteOrder: 20
 		BuildDuration: 700
 		BuildDurationModifier: 40
-		Prerequisites: ~wor, upgrade.wor, ~techlevel.medium
+		Prerequisites: upgrade.wor, ~techlevel.medium
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
 	Valued:
 		Cost: 200

--- a/mods/d2/rules/wor.yaml
+++ b/mods/d2/rules/wor.yaml
@@ -35,10 +35,15 @@ wor:
 		SpawnOffset: 512,480,0
 		ExitCell: 1,2
 	Production:
-		Produces: Infantry
-	PrimaryBuilding:
-		PrimaryCondition: primary
+		Produces: Trooper
 	ProductionBar:
+		ProductionType: Trooper
+	ProductionQueue:
+		Type: Trooper
+		Group: Trooper
+		LowPowerSlowdown: 3
+		BlockedAudio: NoRoom
+		BuildDurationModifier: 250
 	ProvidesPrerequisite@atreides:
 		Prerequisite: wor.atreides
 		Factions: atreides
@@ -71,9 +76,8 @@ upgrade.wor:
 	Tooltip:
 		Name: WOR Upgrade
 	Buildable:
-		BuildPaletteOrder: 30
-		Prerequisites: wor
-		Queue: Upgrade
+		BuildPaletteOrder: 999
+		Queue: Trooper
 		BuildLimit: 1
 		BuildDuration: 250
 		BuildDurationModifier: 40


### PR DESCRIPTION
Closes #77.

I have removed the Queue buttons on the UI too, as i did on Generals Alpha. UI now have a useless area but still imo it is better this way. For both Generals and Dune 2, you had to select the building itself and making that the case on OpenRA makes the mod more unique.

Also upgrade queue is now gone and every upgrade is on its own building, it still don't work as in original tho. I have the logic to make them work on Generals Alpha engine but that is too hacky to ever get to upstream.