### PR TITLE
Check only major version in VOC files

### DIFF
--- a/OpenRA.Mods.D2/AudioLoaders/D2VocLoader.cs
+++ b/OpenRA.Mods.D2/AudioLoaders/D2VocLoader.cs
@@ -120,8 +120,9 @@ namespace OpenRA.Mods.D2.AudioLoaders
 				throw new InvalidDataException("Voc header description not recognized");
 			if (vfh.DatablockOffset != 26)
 				throw new InvalidDataException("Voc header offset is wrong");
-			if (vfh.Version != 0x010A)
-				throw new InvalidDataException("Voc header version not recognized");
+			int majorVersion = vfh.Version >> 8;
+			if (majorVersion != 0x01)
+				throw new InvalidDataException("Voc header version " + vfh.Version.ToString("X") + " not supported");
 			if (vfh.ID != ~vfh.Version + 0x1234)
 				throw new InvalidDataException("Voc header id is bogus - expected: " +
 					(~vfh.Version + 0x1234).ToString("X") + " but value is : " + vfh.ID.ToString("X"));


### PR DESCRIPTION
Closes #99

Current D2VocLoader implementation too strict. it allow to load only VOC files with version 1.10.
Some VOC files can be version 1.20.  Some other versions possibly can be in different PAK files.

Check for major version only. All VOC files version 1.x will be loaded.