### PR TITLE
Unpack and rename files from PAK file to ‘Content/d2/Unpacked' directory

### DIFF
--- a/OpenRA.Mods.D2/D2LoadScreen.cs
+++ b/OpenRA.Mods.D2/D2LoadScreen.cs
@@ -15,6 +15,7 @@ using System.Drawing;
 using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.LoadScreens;
+using OpenRA.Mods.D2;
 using OpenRA.Mods.D2.SpriteLoaders;
 using OpenRA.Widgets;
 
@@ -37,6 +38,16 @@ namespace OpenRA.Mods.D2
 		public override void Init(ModData modData, Dictionary<string, string> info)
 		{
 			base.Init(modData, info);
+
+			/*
+			 * Unpack files needed, because in some PAK files, some VOC files can have prefix 'Z'
+			 * Unpacking files will unpack such files and rename. so no modifications in yaml needed.
+			 */
+			if (D2UnpackContent.UnpackFiles(modData, info) > 0)
+			{
+				// Some files unpacked. need to reload mod packages
+				modData.ModFiles.LoadFromManifest(modData.Manifest);
+			}
 
 			// Avoid standard loading mechanisms so we
 			// can display the loadscreen as early as possible

--- a/OpenRA.Mods.D2/D2UnpackContent.cs
+++ b/OpenRA.Mods.D2/D2UnpackContent.cs
@@ -26,6 +26,23 @@ namespace OpenRA.Mods.D2
 			if (info.ContainsKey("UnpackFiles"))
 				files = info["UnpackFiles"].Split(',');
 
+			if (files.Length == 0)
+				return 0;
+
+			string path = Platform.ResolvePath(Platform.SupportDir);
+
+			string contentPath = Path.Combine(path, "Content");
+			if (!Directory.Exists(contentPath))
+				Directory.CreateDirectory(contentPath);
+
+			string d2Path = Path.Combine(contentPath, "d2");
+			if (!Directory.Exists(d2Path))
+				Directory.CreateDirectory(d2Path);
+
+			string unpackedPath = Path.Combine(d2Path, "Unpacked");
+			if (!Directory.Exists(unpackedPath))
+				Directory.CreateDirectory(unpackedPath);
+
 			foreach (string s in files)
 			{
 				string originalFileName;
@@ -47,20 +64,6 @@ namespace OpenRA.Mods.D2
 				{
 					using (var stream = modData.DefaultFileSystem.Open(originalFileName))
 					{
-						string path = Platform.ResolvePath(Platform.SupportDir);
-
-						string contentPath = Path.Combine(path, "Content");
-						if (!Directory.Exists(contentPath))
-							Directory.CreateDirectory(contentPath);
-
-						string d2Path = Path.Combine(contentPath, "d2");
-						if (!Directory.Exists(d2Path))
-							Directory.CreateDirectory(d2Path);
-
-						string unpackedPath = Path.Combine(d2Path, "Unpacked");
-						if (!Directory.Exists(unpackedPath))
-							Directory.CreateDirectory(unpackedPath);
-
 						string newFileName = Path.Combine(unpackedPath, fileName);
 						if (!File.Exists(newFileName))
 						{
@@ -68,7 +71,7 @@ namespace OpenRA.Mods.D2
  							{
 								stream.CopyTo(fs);
 								unpackedFilesCount += 1;
-								Console.WriteLine("Successful unpack file: {0}", fileName);
+								Console.WriteLine("Successfully unpacked file: {0}", fileName);
 							}
 						}
 					}
@@ -81,6 +84,5 @@ namespace OpenRA.Mods.D2
 
 			return unpackedFilesCount;
 		}
-
 	}
 }

--- a/OpenRA.Mods.D2/D2UnpackContent.cs
+++ b/OpenRA.Mods.D2/D2UnpackContent.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.D2
 		public static int UnpackFiles(ModData modData, Dictionary<string, string> info)
 		{
 			string[] files = {};
-			int unpackedFilesCount = 0;
+			var unpackedFilesCount = 0;
 
 			if (info.ContainsKey("UnpackFiles"))
 				files = info["UnpackFiles"].Split(',');
@@ -29,24 +29,24 @@ namespace OpenRA.Mods.D2
 			if (files.Length == 0)
 				return 0;
 
-			string path = Platform.ResolvePath(Platform.SupportDir);
+			var path = Platform.ResolvePath(Platform.SupportDir);
 
-			string contentPath = Path.Combine(path, "Content");
+			var contentPath = Path.Combine(path, "Content");
 			if (!Directory.Exists(contentPath))
 				Directory.CreateDirectory(contentPath);
 
-			string d2Path = Path.Combine(contentPath, "d2");
+			var d2Path = Path.Combine(contentPath, "d2");
 			if (!Directory.Exists(d2Path))
 				Directory.CreateDirectory(d2Path);
 
-			string unpackedPath = Path.Combine(d2Path, "Unpacked");
+			var unpackedPath = Path.Combine(d2Path, "Unpacked");
 			if (!Directory.Exists(unpackedPath))
 				Directory.CreateDirectory(unpackedPath);
 
-			foreach (string s in files)
+			foreach (var s in files)
 			{
-				string originalFileName;
-				string fileName;
+				var originalFileName = s.Trim();
+				var fileName = originalFileName;
 
 				var explicitSplit = s.IndexOf(':');
 				if (explicitSplit > 0)
@@ -54,31 +54,28 @@ namespace OpenRA.Mods.D2
 					originalFileName = s.Substring(0, explicitSplit).Trim();
 					fileName = s.Substring(explicitSplit + 1).Trim();
 				}
-				else
-				{
-					originalFileName = s.Trim();
-					fileName = originalFileName;
-				}
 
 				try
 				{
-					using (var stream = modData.DefaultFileSystem.Open(originalFileName))
+					if (modData.DefaultFileSystem.Exists(originalFileName))
 					{
-						string newFileName = Path.Combine(unpackedPath, fileName);
-						if (!File.Exists(newFileName))
+						using (var stream = modData.DefaultFileSystem.Open(originalFileName))
 						{
-							using (FileStream fs = new FileStream(newFileName, FileMode.CreateNew, FileAccess.Write))
- 							{
-								stream.CopyTo(fs);
-								unpackedFilesCount += 1;
-								Console.WriteLine("Successfully unpacked file: {0}", fileName);
+							var newFileName = Path.Combine(unpackedPath, fileName);
+							if (!File.Exists(newFileName))
+							{
+								using (FileStream fs = new FileStream(newFileName, FileMode.CreateNew, FileAccess.Write))
+ 								{
+									stream.CopyTo(fs);
+									unpackedFilesCount += 1;
+									Console.WriteLine("Successfully unpacked file: {0}", fileName);
+								}
 							}
 						}
 					}
 				}
-				catch (Exception ex)
+				catch (Exception)
 				{
-					// Console.WriteLine(ex.Message);
 				}
 			}
 

--- a/OpenRA.Mods.D2/D2UnpackContent.cs
+++ b/OpenRA.Mods.D2/D2UnpackContent.cs
@@ -1,0 +1,86 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using OpenRA;
+
+namespace OpenRA.Mods.D2
+{
+	public class D2UnpackContent
+	{
+		public static int UnpackFiles(ModData modData, Dictionary<string, string> info)
+		{
+			string[] files = {};
+			int unpackedFilesCount = 0;
+
+			if (info.ContainsKey("UnpackFiles"))
+				files = info["UnpackFiles"].Split(',');
+
+			foreach (string s in files)
+			{
+				string originalFileName;
+				string fileName;
+
+				var explicitSplit = s.IndexOf(':');
+				if (explicitSplit > 0)
+				{
+					originalFileName = s.Substring(0, explicitSplit).Trim();
+					fileName = s.Substring(explicitSplit + 1).Trim();
+				}
+				else
+				{
+					originalFileName = s.Trim();
+					fileName = originalFileName;
+				}
+
+				try
+				{
+					using (var stream = modData.DefaultFileSystem.Open(originalFileName))
+					{
+						string path = Platform.ResolvePath(Platform.SupportDir);
+
+						string contentPath = Path.Combine(path, "Content");
+						if (!Directory.Exists(contentPath))
+							Directory.CreateDirectory(contentPath);
+
+						string d2Path = Path.Combine(contentPath, "d2");
+						if (!Directory.Exists(d2Path))
+							Directory.CreateDirectory(d2Path);
+
+						string unpackedPath = Path.Combine(d2Path, "Unpacked");
+						if (!Directory.Exists(unpackedPath))
+							Directory.CreateDirectory(unpackedPath);
+
+						string newFileName = Path.Combine(unpackedPath, fileName);
+						if (!File.Exists(newFileName))
+						{
+							using (FileStream fs = new FileStream(newFileName, FileMode.CreateNew, FileAccess.Write))
+ 							{
+								stream.CopyTo(fs);
+								unpackedFilesCount += 1;
+								Console.WriteLine("Successful unpack file: {0}", fileName);
+							}
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					// Console.WriteLine(ex.Message);
+				}
+			}
+
+			return unpackedFilesCount;
+		}
+
+	}
+}

--- a/OpenRA.Mods.D2/OpenRA.Mods.D2.csproj
+++ b/OpenRA.Mods.D2/OpenRA.Mods.D2.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Traits\World\D2TerrainLayer.cs" />
     <Compile Include="Traits\PaletteEffects\D2WindtrapPaletteEffect.cs" />
     <Compile Include="Traits\World\D2ShroudRenderer.cs" />
+    <Compile Include="D2UnpackContent.cs" />
     <Compile Include="D2LoadScreen.cs" />
     <Compile Include="Traits\Buildings\D2Building.cs" />
     <Compile Include="Traits\Buildings\D2Concrete.cs" />

--- a/mods/d2/audio/voices.yaml
+++ b/mods/d2/audio/voices.yaml
@@ -24,7 +24,7 @@ InfantryVoice:
 #		Guard: I_GUARD
 
 FremenVoice:
-	DefaultVariant: .AUD
+	DefaultVariant: .VOC
 	Voices:
 		Select: REPORT1, REPORT2, REPORT3
 		Action: MOVEOUT, OVEROUT, AFFIRM
@@ -32,7 +32,7 @@ FremenVoice:
 #		Guard: I_GUARD
 
 SaboteurVoice:
-	DefaultVariant: .AUD
+	DefaultVariant: .VOC
 	Voices:
 		Select: REPORT1, REPORT2, REPORT3
 		Action: MOVEOUT, OVEROUT, AFFIRM

--- a/mods/d2/mod.yaml
+++ b/mods/d2/mod.yaml
@@ -5,14 +5,15 @@ Metadata:
 PackageFormats: PakFile, D2kSoundResources
 
 Packages:
+	~^Content/d2/Unpacked
+	~^Content/d2
+	~^Content/d2k/v2
 	.
 	$d2: d2
 	$d2k: d2k
 	$ra: ra
 	$cnc: cnc
 	./mods/common: common
-	~^Content/d2
-	~^Content/d2k/v2
 	~DUNE.PAK
 	~VOC.PAK
 	~ATRE.PAK
@@ -254,6 +255,7 @@ LoadScreen: D2LoadScreen
 	Image: BIGPLAN.CPS
 	Palette: IBM.PAL
 	Text: Loading DOS emulator..., Looking for CRT..., Rewinding floppy disks..., Recount the bytes..., Initialize Upper memory..., Combine bits into bytes..., Looking for additional 64Kbytes...
+	UnpackFiles: ZREPORT1.VOC:REPORT1.VOC, ZREPORT2.VOC:REPORT2.VOC, ZREPORT3.VOC:REPORT3.VOC, ZMOVEOUT.VOC:MOVEOUT.VOC, ZOVEROUT.VOC:OVEROUT.VOC, ZAFFIRM.VOC:AFFIRM.VOC
 
 ServerTraits:
 	LobbyCommands


### PR DESCRIPTION
Closes #95 and Closes #36 

Unpack and rename files needed, because some PAK files can contain sound files with prefix ‘Z’
This pull request will rename such files, and remove prefix ‘Z’. No other changes in yaml or engine needed for this files to play.