### PR TITLE
Fix Death Hand Missile charge time

### DIFF
--- a/mods/d2/rules/palace.yaml
+++ b/mods/d2/rules/palace.yaml
@@ -62,7 +62,7 @@ palace:
 		Icon: deathhand
 		PauseOnCondition: disabled
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke
-		ChargeTime: 7500
+		ChargeInterval: 7500
 		Description: Death Hand
 		LongDesc: Launches an atomic missile at a target location
 		BeginChargeSpeechNotification: DeathHandMissilePrepping


### PR DESCRIPTION
Not sure if 7500 is correct to original but better 5 mins than instant.