### PR TITLE
Buildings placement

### DIFF
--- a/OpenRA.Mods.D2/Graphics/D2BuildingPlacementRenderable.cs
+++ b/OpenRA.Mods.D2/Graphics/D2BuildingPlacementRenderable.cs
@@ -1,0 +1,73 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Widgets;
+using OpenRA.Mods.Common.Graphics;
+
+
+namespace OpenRA.Mods.D2.Graphics
+{
+	public struct D2BuildingPlacementRenderable : IRenderable, IFinalizedRenderable
+	{
+		readonly WPos pos;
+		readonly Rectangle decorationBounds;
+		readonly Color color;
+		readonly bool crossEnabled;
+
+		public D2BuildingPlacementRenderable(Actor actor, Rectangle decorationBounds, Color color, bool crossEnabled)
+			: this(actor.CenterPosition, decorationBounds, color, crossEnabled) { }
+
+		public D2BuildingPlacementRenderable(WPos pos, Rectangle decorationBounds, Color color, bool crossEnabled)
+		{
+			this.pos = pos;
+			this.decorationBounds = decorationBounds;
+			this.color = color;
+			this.crossEnabled = crossEnabled;
+		}
+
+		public WPos Pos { get { return pos; } }
+
+		public PaletteReference Palette { get { return null; } }
+		public int ZOffset { get { return 0; } }
+		public bool IsDecoration { get { return true; } }
+
+		public IRenderable WithPalette(PaletteReference newPalette) { return this; }
+		public IRenderable WithZOffset(int newOffset) { return this; }
+		public IRenderable OffsetBy(WVec vec) { return new D2BuildingPlacementRenderable(pos + vec, decorationBounds, color, crossEnabled); }
+		public IRenderable AsDecoration() { return this; }
+
+		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
+
+		public void Render(WorldRenderer wr)
+		{
+			var tl = new WPos(pos.X + decorationBounds.Left, pos.Y + decorationBounds.Top, 0);
+			var br = new WPos(pos.X + decorationBounds.Width, pos.Y + decorationBounds.Height, 0);
+			var tlOffset = wr.Screen3DPxPosition(tl);
+			var brOffset = wr.Screen3DPxPosition(br);
+			var width = 1.0f;// / wr.Viewport.Zoom;
+			Game.Renderer.WorldRgbaColorRenderer.DrawRect(tlOffset, brOffset, width, color);
+			if (crossEnabled)
+			{
+				Game.Renderer.WorldRgbaColorRenderer.DrawLine(tlOffset, brOffset, width, color);
+				var trOffset = new float3(brOffset.X, tlOffset.Y, tlOffset.Z);
+				var blOffset = new float3(tlOffset.X, brOffset.Y, tlOffset.Z);
+				Game.Renderer.WorldRgbaColorRenderer.DrawLine(trOffset, blOffset, width, color);
+			}
+		}
+
+		public void RenderDebugGeometry(WorldRenderer wr) { } 
+
+		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }
+	}
+}

--- a/OpenRA.Mods.D2/Graphics/D2BuildingPlacementRenderable.cs
+++ b/OpenRA.Mods.D2/Graphics/D2BuildingPlacementRenderable.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.D2.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			var tl = new WPos(pos.X + decorationBounds.Left, pos.Y + decorationBounds.Top, 0);
-			var br = new WPos(pos.X + decorationBounds.Width, pos.Y + decorationBounds.Height, 0);
+			var br = new WPos(pos.X + decorationBounds.Width - 1, pos.Y + decorationBounds.Height - 1, 0);
 			var tlOffset = wr.Screen3DPxPosition(tl);
 			var brOffset = wr.Screen3DPxPosition(br);
 			var width = 1.0f;// / wr.Viewport.Zoom;

--- a/OpenRA.Mods.D2/OpenRA.Mods.D2.csproj
+++ b/OpenRA.Mods.D2/OpenRA.Mods.D2.csproj
@@ -44,26 +44,33 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AudioLoaders\D2VocLoader.cs" />
+    <Compile Include="FileFormats\WsaReader.cs" />
+    <Compile Include="Graphics\D2BuildingPlacementRenderable.cs" />
     <Compile Include="SpriteLoaders\IcnD2Loader.cs" />
     <Compile Include="SpriteLoaders\CpsD2Loader.cs" />
     <Compile Include="SpriteLoaders\WsaLoader.cs" />
+    <Compile Include="Traits\Buildings\D2Building.cs" />
+    <Compile Include="Traits\Buildings\D2BuildingPlacement.cs" />
+    <Compile Include="Traits\Buildings\D2Concrete.cs" />
+    <Compile Include="Traits\Buildings\D2ConcreteOwners.cs" />
+    <Compile Include="Traits\Buildings\D2Refinery.cs" />
+    <Compile Include="Traits\D2AffectsShroud.cs" />
+    <Compile Include="Traits\D2RevealsShroud.cs" />
+    <Compile Include="Traits\PaletteEffects\D2WindtrapPaletteEffect.cs" />
     <Compile Include="Traits\Render\WithTilesetBody.cs" />
+    <Compile Include="Traits\Render\D2WithIdleOverlay.cs " />
+    <Compile Include="Traits\Render\D2WithSpriteBody.cs " />
+    <Compile Include="Traits\Render\D2WithSpriteTurret.cs " />
+    <Compile Include="Traits\Render\D2WithWallSpriteBody.cs " />
     <Compile Include="Traits\World\D2ResourceLayer.cs" />
     <Compile Include="Traits\World\D2EditorResourceLayer.cs" />
     <Compile Include="Traits\World\D2TerrainLayer.cs" />
-    <Compile Include="Traits\PaletteEffects\D2WindtrapPaletteEffect.cs" />
     <Compile Include="Traits\World\D2ShroudRenderer.cs" />
-    <Compile Include="D2UnpackContent.cs" />
-    <Compile Include="D2LoadScreen.cs" />
-    <Compile Include="Traits\Buildings\D2Building.cs" />
-    <Compile Include="Traits\Buildings\D2Concrete.cs" />
-    <Compile Include="Traits\Buildings\D2ConcreteOwners.cs" />
-    <Compile Include="Traits\D2AffectsShroud.cs" />
-    <Compile Include="Traits\D2RevealsShroud.cs" />
     <Compile Include="Widgets\WsaPlayerWidget.cs" />
     <Compile Include="Widgets\Logic\D2AssetBrowserLogic.cs" />
     <Compile Include="Widgets\Logic\D2MissionBrowserLogic.cs" />
-    <Compile Include="FileFormats\WsaReader.cs" />
+    <Compile Include="D2UnpackContent.cs" />
+    <Compile Include="D2LoadScreen.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Widgets\Logic\" />

--- a/OpenRA.Mods.D2/Traits/Buildings/D2BuildingPlacement.cs
+++ b/OpenRA.Mods.D2/Traits/Buildings/D2BuildingPlacement.cs
@@ -25,10 +25,23 @@ namespace OpenRA.Mods.D2.Traits
 
 	public class D2BuildingPlacementInfo : ITraitInfo, IPlaceBuildingDecorationInfo
 	{
+		float t = 0.0f;
+		float step = 0.03f;
+
+		void Tick()
+		{
+			t += step;
+			if (t >= 1.0f || t <= 0) step = -step;
+			if (t > 1.0f) t = 1.0f;
+			if (t < 0.0f) t = 0.0f;
+		}
+
 		public object Create(ActorInitializer init) { return new D2BuildingPlacement(init.Self); }
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
+			Tick();
+
 			var bi = ai.TraitInfoOrDefault<D2BuildingInfo>();
 
 			var width = bi.Dimensions.X * 1024;
@@ -40,7 +53,10 @@ namespace OpenRA.Mods.D2.Traits
 			var topLeft = new WPos(centerPosition.X - width / 2 + 512, centerPosition.Y - height / 2 + 512, 0);
 			var isCloseEnough = bi.IsCloseEnoughToBase(w, w.LocalPlayer, ai, w.Map.CellContaining(topLeft));
 
-			return new IRenderable[] { new D2BuildingPlacementRenderable(centerPosition, bounds, Color.White, !isCloseEnough) };
+			var colorComponent = (int)Math.Round(127 + 127 * t);
+			var color = Color.FromArgb(255, colorComponent, colorComponent, colorComponent);
+
+			return new IRenderable[] { new D2BuildingPlacementRenderable(centerPosition, bounds, color, !isCloseEnough) };
 		}
 	}
 

--- a/OpenRA.Mods.D2/Traits/Buildings/D2BuildingPlacement.cs
+++ b/OpenRA.Mods.D2/Traits/Buildings/D2BuildingPlacement.cs
@@ -1,0 +1,51 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Mods.D2.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits
+{
+
+	public class D2BuildingPlacementInfo : ITraitInfo, IPlaceBuildingDecorationInfo
+	{
+		public object Create(ActorInitializer init) { return new D2BuildingPlacement(init.Self); }
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		{
+			var bi = ai.TraitInfoOrDefault<D2BuildingInfo>();
+
+			var width = bi.Dimensions.X * 1024;
+			var height = bi.Dimensions.Y * 1024;
+			var halfWidth = width / 2;
+			var halfHeight = height / 2;
+
+			var bounds = new Rectangle(-halfWidth, -halfHeight, width - halfWidth, height - halfHeight);
+			var topLeft = new WPos(centerPosition.X - width / 2 + 512, centerPosition.Y - height / 2 + 512, 0);
+			var isCloseEnough = bi.IsCloseEnoughToBase(w, w.LocalPlayer, ai, w.Map.CellContaining(topLeft));
+
+			return new IRenderable[] { new D2BuildingPlacementRenderable(centerPosition, bounds, Color.White, !isCloseEnough) };
+		}
+	}
+
+	public class D2BuildingPlacement
+	{
+		public D2BuildingPlacement(Actor self) { }
+	}
+}

--- a/OpenRA.Mods.D2/Traits/Buildings/D2BuildingPlacement.cs
+++ b/OpenRA.Mods.D2/Traits/Buildings/D2BuildingPlacement.cs
@@ -44,19 +44,41 @@ namespace OpenRA.Mods.D2.Traits
 
 			var bi = ai.TraitInfoOrDefault<D2BuildingInfo>();
 
-			var width = bi.Dimensions.X * 1024;
-			var height = bi.Dimensions.Y * 1024;
+			var cols = bi.Dimensions.X;
+			var rows = bi.Dimensions.Y;
+
+			var width = cols * 1024;
+			var height = rows * 1024;
 			var halfWidth = width / 2;
 			var halfHeight = height / 2;
 
-			var bounds = new Rectangle(-halfWidth, -halfHeight, width - halfWidth, height - halfHeight);
+			var bounds = new Rectangle(-halfWidth, -halfHeight, width - halfWidth - 1, height - halfHeight - 1);
 			var topLeft = new WPos(centerPosition.X - width / 2 + 512, centerPosition.Y - height / 2 + 512, 0);
-			var isCloseEnough = bi.IsCloseEnoughToBase(w, w.LocalPlayer, ai, w.Map.CellContaining(topLeft));
+			var topLeftCell = w.Map.CellContaining(topLeft);
+			var isCloseEnough = bi.IsCloseEnoughToBase(w, w.LocalPlayer, ai, topLeftCell);
+			var isBuildable = true;
+
+			for (var y = 0; y < rows; y ++)
+			{
+				for (var x = 0; x < cols; x++)
+				{
+					var cellPos = new CPos(topLeftCell.X + x, topLeftCell.Y + y);
+					if (!w.IsCellBuildable(cellPos, ai, bi))
+					{
+						isBuildable = false;
+						break;
+					}
+				}
+				if (!isBuildable)
+				{
+					break;
+				}
+			}
 
 			var colorComponent = (int)Math.Round(127 + 127 * t);
 			var color = Color.FromArgb(255, colorComponent, colorComponent, colorComponent);
 
-			return new IRenderable[] { new D2BuildingPlacementRenderable(centerPosition, bounds, color, !isCloseEnough) };
+			return new IRenderable[] { new D2BuildingPlacementRenderable(centerPosition, bounds, color, !isCloseEnough || !isBuildable) };
 		}
 	}
 

--- a/OpenRA.Mods.D2/Traits/Buildings/D2Concrete.cs
+++ b/OpenRA.Mods.D2/Traits/Buildings/D2Concrete.cs
@@ -21,6 +21,6 @@ namespace OpenRA.Mods.D2.Traits
 
 	public class D2Concrete
 	{
-		public D2Concrete(Actor selfo) { }
+		public D2Concrete(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.D2/Traits/Buildings/D2Refinery.cs
+++ b/OpenRA.Mods.D2/Traits/Buildings/D2Refinery.cs
@@ -1,0 +1,186 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits
+{
+	public class D2RefineryInfo : IAcceptResourcesInfo
+	{
+		[Desc("Actual harvester facing when docking, 0-255 counter-clock-wise.")]
+		public readonly int DockAngle = 0;
+
+		[Desc("Docking cell relative to top-left cell.")]
+		public readonly CVec DockOffset = CVec.Zero;
+
+		[Desc("Does the refinery require the harvester to be dragged in?")]
+		public readonly bool IsDragRequired = false;
+
+		[Desc("Vector by which the harvester will be dragged when docking.")]
+		public readonly WVec DragOffset = WVec.Zero;
+
+		[Desc("In how many steps to perform the dragging?")]
+		public readonly int DragLength = 0;
+
+		[Desc("Store resources in silos. Adds cash directly without storing if set to false.")]
+		public readonly bool UseStorage = true;
+
+		[Desc("Discard resources once silo capacity has been reached.")]
+		public readonly bool DiscardExcessResources = false;
+
+		public readonly bool ShowTicks = true;
+		public readonly int TickLifetime = 30;
+		public readonly int TickVelocity = 2;
+		public readonly int TickRate = 10;
+
+		public virtual object Create(ActorInitializer init) { return new D2Refinery(init.Self, this); }
+	}
+
+	public class D2Refinery : ITick, IAcceptResources, INotifySold, INotifyCapture, INotifyOwnerChanged, IExplodeModifier, ISync, INotifyActorDisposing
+	{
+		readonly Actor self;
+		readonly D2RefineryInfo info;
+		PlayerResources playerResources;
+
+		int currentDisplayTick = 0;
+		int currentDisplayValue = 0;
+
+		[Sync] public int Ore = 0;
+		[Sync] Actor dockedHarv = null;
+		[Sync] bool preventDock = false;
+
+		public bool AllowDocking { get { return !preventDock; } }
+		public CVec DeliveryOffset { get { return info.DockOffset; } }
+		public int DeliveryAngle { get { return info.DockAngle; } }
+		public bool IsDragRequired { get { return info.IsDragRequired; } }
+		public WVec DragOffset { get { return info.DragOffset; } }
+		public int DragLength { get { return info.DragLength; } }
+
+		public D2Refinery(Actor self, D2RefineryInfo info)
+		{
+			this.self = self;
+			this.info = info;
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+			currentDisplayTick = info.TickRate;
+		}
+
+		public virtual Activity DockSequence(Actor harv, Actor self)
+		{
+			return new SpriteHarvesterDockSequence(harv, self, DeliveryAngle, IsDragRequired, DragOffset, DragLength);
+		}
+
+		public IEnumerable<TraitPair<Harvester>> GetLinkedHarvesters()
+		{
+			return self.World.ActorsWithTrait<Harvester>()
+				.Where(a => a.Trait.LinkedProc == self);
+		}
+
+		public bool CanGiveResource(int amount) { return !info.UseStorage || info.DiscardExcessResources || playerResources.CanGiveResources(amount); }
+
+		public void GiveResource(int amount)
+		{
+			if (info.UseStorage)
+			{
+				if (info.DiscardExcessResources)
+					amount = Math.Min(amount, playerResources.ResourceCapacity - playerResources.Resources);
+
+				playerResources.GiveResources(amount);
+			}
+			else
+				amount = playerResources.ChangeCash(amount);
+
+			if (info.ShowTicks)
+				currentDisplayValue += amount;
+		}
+
+		void CancelDock(Actor self)
+		{
+			preventDock = true;
+
+			// Cancel the dock sequence
+			if (dockedHarv != null && !dockedHarv.IsDead)
+				dockedHarv.CancelActivity();
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			// Harvester was killed while unloading
+			if (dockedHarv != null && dockedHarv.IsDead)
+				dockedHarv = null;
+
+			if (info.ShowTicks && currentDisplayValue > 0 && --currentDisplayTick <= 0)
+			{
+				var temp = currentDisplayValue;
+				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
+					self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color.RGB, FloatingText.FormatCashTick(temp), 30)));
+				currentDisplayTick = info.TickRate;
+				currentDisplayValue = 0;
+			}
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			CancelDock(self);
+			foreach (var harv in GetLinkedHarvesters())
+				harv.Trait.UnlinkProc(harv.Actor, self);
+		}
+
+		public void OnDock(Actor harv, DeliverResources dockOrder)
+		{
+			if (!preventDock)
+			{
+				dockOrder.Queue(new CallFunc(() => dockedHarv = harv, false));
+				dockOrder.Queue(DockSequence(harv, self));
+				dockOrder.Queue(new CallFunc(() => dockedHarv = null, false));
+			}
+
+			dockOrder.Queue(new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			// Unlink any harvesters
+			foreach (var harv in GetLinkedHarvesters())
+				harv.Trait.UnlinkProc(harv.Actor, self);
+
+			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
+		}
+
+		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		{
+			// Steal any docked harv too
+			if (dockedHarv != null)
+			{
+				dockedHarv.ChangeOwner(newOwner);
+
+				// Relink to this refinery
+				dockedHarv.Trait<Harvester>().LinkProc(dockedHarv, self);
+			}
+		}
+
+		void INotifySold.Selling(Actor self) { CancelDock(self); }
+		void INotifySold.Sold(Actor self)
+		{
+			foreach (var harv in GetLinkedHarvesters())
+				harv.Trait.UnlinkProc(harv.Actor, self);
+		}
+
+		public bool ShouldExplode(Actor self) { return Ore > 0; }
+	}
+}

--- a/OpenRA.Mods.D2/Traits/Render/D2WithIdleOverlay.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2WithIdleOverlay.cs
@@ -1,0 +1,97 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits.Render
+{
+	[Desc("Renders a decorative animation on units and buildings.")]
+	public class D2WithIdleOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	{
+		[Desc("Animation to play when the actor is created.")]
+		[SequenceReference] public readonly string StartSequence = null;
+
+		[Desc("Sequence name to use")]
+		[SequenceReference] public readonly string Sequence = "idle-overlay";
+
+		[Desc("Position relative to body")]
+		public readonly WVec Offset = WVec.Zero;
+
+		[Desc("Custom palette name")]
+		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+
+		[Desc("Custom palette is a player palette BaseName")]
+		public readonly bool IsPlayerPalette = false;
+
+		// TODO: Remove this when the buildComplete code is replaced with conditions.
+		public readonly bool RenderBeforeBuildComplete = false;
+
+		public override object Create(ActorInitializer init) { return new D2WithIdleOverlay(init.Self, this); }
+	}
+
+	public class D2WithIdleOverlay : PausableConditionalTrait<D2WithIdleOverlayInfo>, INotifyDamageStateChanged, INotifyBuildComplete, INotifySold, INotifyTransform
+	{
+		readonly Animation overlay;
+		bool buildComplete;
+
+		public D2WithIdleOverlay(Actor self, D2WithIdleOverlayInfo info)
+			: base(info)
+		{
+			var rs = self.Trait<RenderSprites>();
+			var body = self.Trait<BodyOrientation>();
+
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
+			overlay = new Animation(self.World, rs.GetImage(self), () => IsTraitPaused || (!info.RenderBeforeBuildComplete && !buildComplete));
+			if (info.StartSequence != null)
+				overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.StartSequence),
+					() => overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence)));
+			else
+				overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence));
+
+			var anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => IsTraitDisabled || (!info.RenderBeforeBuildComplete && !buildComplete),
+				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
+
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+		}
+
+		void INotifyBuildComplete.BuildingComplete(Actor self)
+		{
+			buildComplete = true;
+		}
+
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		void INotifyTransform.BeforeTransform(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor self) { }
+
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		{
+			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, overlay.CurrentSequence.Name));
+		}
+	}
+}

--- a/OpenRA.Mods.D2/Traits/Render/D2WithSpriteBody.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2WithSpriteBody.cs
@@ -1,0 +1,132 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits.Render
+{
+	[Desc("Default trait for rendering sprite-based actors.")]
+	public class D2WithSpriteBodyInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>
+	{
+		[Desc("Animation to play when the actor is created."), SequenceReference]
+		public readonly string StartSequence = null;
+
+		[Desc("Animation to play when the actor is idle."), SequenceReference]
+		public readonly string Sequence = "idle";
+
+		[Desc("Identifier used to assign modifying traits to this sprite body.")]
+		public readonly string Name = "body";
+
+		public override object Create(ActorInitializer init) { return new D2WithSpriteBody(init, this); }
+	}
+
+	public class D2WithSpriteBody : PausableConditionalTrait<D2WithSpriteBodyInfo>, INotifyDamageStateChanged, INotifyBuildComplete, IAutoMouseBounds
+	{
+		public readonly Animation DefaultAnimation;
+		readonly RenderSprites rs;
+		readonly Animation boundsAnimation;
+
+		public D2WithSpriteBody(ActorInitializer init, D2WithSpriteBodyInfo info)
+			: this(init, info, () => 0) { }
+
+		protected D2WithSpriteBody(ActorInitializer init, D2WithSpriteBodyInfo info, Func<int> baseFacing)
+			: base(info)
+		{
+			rs = init.Self.Trait<RenderSprites>();
+
+			Func<bool> paused = () => IsTraitPaused &&
+				DefaultAnimation.CurrentSequence.Name == NormalizeSequence(init.Self, Info.Sequence);
+
+			DefaultAnimation = new Animation(init.World, rs.GetImage(init.Self), baseFacing, paused);
+			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
+
+			// Cache the bounds from the default sequence to avoid flickering when the animation changes
+			boundsAnimation = new Animation(init.World, rs.GetImage(init.Self), baseFacing, paused);
+			boundsAnimation.PlayRepeating(info.Sequence);
+
+			if (info.StartSequence != null)
+				PlayCustomAnimation(init.Self, info.StartSequence,
+					() => PlayCustomAnimationRepeating(init.Self, info.Sequence));
+			else
+				DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence));
+		}
+
+		public string NormalizeSequence(Actor self, string sequence)
+		{
+			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
+		}
+
+		protected virtual void OnBuildComplete(Actor self)
+		{
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+		}
+
+		// TODO: Get rid of INotifyBuildComplete in favor of using the condition system
+		void INotifyBuildComplete.BuildingComplete(Actor self)
+		{
+			OnBuildComplete(self);
+		}
+
+		public void PlayCustomAnimation(Actor self, string name, Action after = null)
+		{
+			DefaultAnimation.PlayThen(NormalizeSequence(self, name), () =>
+			{
+				CancelCustomAnimation(self);
+				if (after != null)
+					after();
+			});
+		}
+
+		public void PlayCustomAnimationRepeating(Actor self, string name)
+		{
+			var sequence = NormalizeSequence(self, name);
+			DefaultAnimation.PlayThen(sequence, () => PlayCustomAnimationRepeating(self, sequence));
+		}
+
+		public void PlayCustomAnimationBackwards(Actor self, string name, Action after = null)
+		{
+			DefaultAnimation.PlayBackwardsThen(NormalizeSequence(self, name), () =>
+			{
+				CancelCustomAnimation(self);
+				if (after != null)
+					after();
+			});
+		}
+
+		public void CancelCustomAnimation(Actor self)
+		{
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+		}
+
+		protected virtual void DamageStateChanged(Actor self)
+		{
+			if (DefaultAnimation.CurrentSequence != null)
+				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
+		}
+
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		{
+			DamageStateChanged(self);
+		}
+
+		Rectangle IAutoMouseBounds.AutoMouseoverBounds(Actor self, WorldRenderer wr)
+		{
+			return boundsAnimation.ScreenBounds(wr, self.CenterPosition, WVec.Zero, rs.Info.Scale);
+		}
+	}
+}

--- a/OpenRA.Mods.D2/Traits/Render/D2WithSpriteTurret.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2WithSpriteTurret.cs
@@ -1,0 +1,122 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Mods.D2.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits.Render
+{
+	[Desc("Renders turrets for units with the Turreted trait.")]
+	public class D2WithSpriteTurretInfo : ConditionalTraitInfo,
+		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<BodyOrientationInfo>, Requires<ArmamentInfo>
+	{
+		[Desc("Sequence name to use")]
+		[SequenceReference] public readonly string Sequence = "turret";
+
+		[Desc("Turreted 'Turret' key to display")]
+		public readonly string Turret = "primary";
+
+		[Desc("Render recoil")]
+		public readonly bool Recoils = true;
+
+		public override object Create(ActorInitializer init) { return new D2WithSpriteTurret(init.Self, this); }
+	}
+
+	public class D2WithSpriteTurret : ConditionalTrait<D2WithSpriteTurretInfo>, INotifyBuildComplete, INotifySold, INotifyTransform, INotifyDamageStateChanged
+	{
+		public readonly Animation DefaultAnimation;
+		readonly RenderSprites rs;
+		readonly BodyOrientation body;
+		readonly Turreted t;
+		readonly Armament[] arms;
+
+		// TODO: This should go away once https://github.com/OpenRA/OpenRA/issues/7035 is implemented
+		bool buildComplete;
+
+		public D2WithSpriteTurret(Actor self, D2WithSpriteTurretInfo info)
+			: base(info)
+		{
+			rs = self.Trait<RenderSprites>();
+			body = self.Trait<BodyOrientation>();
+			t = self.TraitsImplementing<Turreted>()
+				.First(tt => tt.Name == info.Turret);
+			arms = self.TraitsImplementing<Armament>()
+				.Where(w => w.Info.Turret == info.Turret).ToArray();
+			buildComplete = !self.Info.HasTraitInfo<D2BuildingInfo>(); // always render instantly for units
+
+			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => t.TurretFacing);
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
+			rs.Add(new AnimationWithOffset(DefaultAnimation,
+				() => TurretOffset(self),
+				() => IsTraitDisabled || !buildComplete,
+				p => RenderUtils.ZOffsetFromCenter(self, p, 1)));
+
+			// Restrict turret facings to match the sprite
+			t.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
+		}
+
+		protected virtual WVec TurretOffset(Actor self)
+		{
+			if (!Info.Recoils)
+				return t.Position(self);
+
+			var recoil = arms.Aggregate(WDist.Zero, (a, b) => a + b.Recoil);
+			var localOffset = new WVec(-recoil, WDist.Zero, WDist.Zero);
+			var quantizedWorldTurret = t.WorldOrientation(self);
+			return t.Position(self) + body.LocalToWorld(localOffset.Rotate(quantizedWorldTurret));
+		}
+
+		public string NormalizeSequence(Actor self, string sequence)
+		{
+			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
+		}
+
+		protected virtual void DamageStateChanged(Actor self)
+		{
+			if (DefaultAnimation.CurrentSequence != null)
+				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
+		}
+
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		{
+			DamageStateChanged(self);
+		}
+
+		public void PlayCustomAnimation(Actor self, string name, Action after = null)
+		{
+			DefaultAnimation.PlayThen(NormalizeSequence(self, name), () =>
+			{
+				CancelCustomAnimation(self);
+				if (after != null)
+					after();
+			});
+		}
+
+		public void CancelCustomAnimation(Actor self)
+		{
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+		}
+
+		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }
+		void INotifySold.Selling(Actor self) { buildComplete = false; }
+		void INotifySold.Sold(Actor self) { }
+		void INotifyTransform.BeforeTransform(Actor self) { buildComplete = false; }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor toActor) { }
+	}
+}

--- a/OpenRA.Mods.D2/Traits/Render/D2WithWallSpriteBody.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2WithWallSpriteBody.cs
@@ -1,0 +1,137 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits.Render
+{
+	[RequireExplicitImplementation]
+	interface ID2WallConnectorInfo : ITraitInfoInterface
+	{
+		string GetWallConnectionType();
+	}
+
+	interface ID2WallConnector
+	{
+		bool AdjacentWallCanConnect(Actor self, CPos wallLocation, string wallType, out CVec facing);
+		void SetDirty();
+	}
+
+	[Desc("Render trait for actors that change sprites if neighbors with the same trait are present.")]
+	class D2WithWallSpriteBodyInfo : D2WithSpriteBodyInfo, ID2WallConnectorInfo, Requires<BuildingInfo>
+	{
+		public readonly string Type = "wall";
+
+		public override object Create(ActorInitializer init) { return new D2WithWallSpriteBody(init, this); }
+
+		string ID2WallConnectorInfo.GetWallConnectionType()
+		{
+			return Type;
+		}
+	}
+
+	class D2WithWallSpriteBody : D2WithSpriteBody, INotifyRemovedFromWorld, ID2WallConnector, ITick
+	{
+		readonly D2WithWallSpriteBodyInfo wallInfo;
+		int adjacent = 0;
+		bool dirty = true;
+
+		bool ID2WallConnector.AdjacentWallCanConnect(Actor self, CPos wallLocation, string wallType, out CVec facing)
+		{
+			facing = wallLocation - self.Location;
+			return wallInfo.Type == wallType && Math.Abs(facing.X) + Math.Abs(facing.Y) == 1;
+		}
+
+		void ID2WallConnector.SetDirty() { dirty = true; }
+
+		public D2WithWallSpriteBody(ActorInitializer init, D2WithWallSpriteBodyInfo info)
+			: base(init, info, () => 0)
+		{
+			wallInfo = info;
+		}
+
+		protected override void DamageStateChanged(Actor self)
+		{
+			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (!dirty)
+				return;
+
+			// Update connection to neighbours
+			var adjacentActors = CVec.Directions.SelectMany(dir =>
+				self.World.ActorMap.GetActorsAt(self.Location + dir));
+
+			adjacent = 0;
+			foreach (var a in adjacentActors)
+			{
+				CVec facing;
+				var wc = a.TraitsImplementing<ID2WallConnector>().FirstEnabledTraitOrDefault();
+				if (wc == null || !wc.AdjacentWallCanConnect(a, self.Location, wallInfo.Type, out facing))
+					continue;
+
+				if (facing.Y > 0)
+					adjacent |= 1;
+				else if (facing.X < 0)
+					adjacent |= 2;
+				else if (facing.Y < 0)
+					adjacent |= 4;
+				else if (facing.X > 0)
+					adjacent |= 8;
+			}
+
+			dirty = false;
+		}
+
+		protected override void OnBuildComplete(Actor self)
+		{
+			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
+			UpdateNeighbours(self);
+
+			// Set the initial animation frame before the render tick (for frozen actor previews)
+			self.World.AddFrameEndTask(_ => DefaultAnimation.Tick());
+		}
+
+		static void UpdateNeighbours(Actor self)
+		{
+			var adjacentActorTraits = CVec.Directions.SelectMany(dir =>
+					self.World.ActorMap.GetActorsAt(self.Location + dir))
+				.SelectMany(a => a.TraitsImplementing<ID2WallConnector>());
+
+			foreach (var aat in adjacentActorTraits)
+				aat.SetDirty();
+		}
+
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
+		{
+			UpdateNeighbours(self);
+		}
+
+		protected override void TraitEnabled(Actor self) { dirty = true; }
+	}
+
+	public class RuntimeNeighbourInit : IActorInit<Dictionary<CPos, string[]>>, ISuppressInitExport
+	{
+		[FieldFromYamlKey] readonly Dictionary<CPos, string[]> value = null;
+		public RuntimeNeighbourInit() { }
+		public RuntimeNeighbourInit(Dictionary<CPos, string[]> init) { value = init; }
+		public Dictionary<CPos, string[]> Value(World world) { return value; }
+	}
+}

--- a/OpenRA.Mods.D2/Traits/Render/WithTilesetBody.cs
+++ b/OpenRA.Mods.D2/Traits/Render/WithTilesetBody.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2.Traits
 {
-	public class WithTilesetBodyInfo : ITraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
+	public class WithTilesetBodyInfo : ITraitInfo, Requires<BuildingInfo>, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference] public readonly string Sequence = "idle-tileset";
 		[PaletteReference] public readonly string Palette = null;
@@ -28,35 +28,6 @@ namespace OpenRA.Mods.D2.Traits
 		public readonly int[] SkipFrames;
 
 		public object Create(ActorInitializer init) { return new WithTilesetBody(init.Self, this); }
-
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
-		{
-			if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
-
-			var bi = init.Actor.TraitInfo<BuildingInfo>();
-
-			var cols = bi.Dimensions.X;
-			var rows = bi.Dimensions.Y;
-
-			for (var index = 0; index < (cols * rows); index++)
-			{
-				if (SkipFrames == null || !SkipFrames.Contains(index)) {
-					var y = index / cols;
-					var x = index % cols;
-
-					var anim = new Animation(init.World, image);
-					Func<WVec> offset = () => new WVec(x * 1024 - 512, y * 1024 - 512, 0);
-					Func<int> zOffset = () => 0;
-
-					var frameIndex = index;
-					anim.PlayFetchIndex(Sequence, () => frameIndex);
-					anim.IsDecoration = true;
-
-					yield return new SpriteActorPreview(anim, offset, zOffset, p, rs.Scale);
-				}
-			}
-		}
 	}
 
 	public class WithTilesetBody

--- a/mods/d2/rules/barracks.yaml
+++ b/mods/d2/rules/barracks.yaml
@@ -60,7 +60,7 @@ barracks:
 		PlayerPalette: player
 	WithTilesetBody:
 		SkipFrames: 3
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	ProvidesPrerequisite@buildingname:
 	ProvidesPrerequisite@har_conyard_or_barracks:

--- a/mods/d2/rules/building.yaml
+++ b/mods/d2/rules/building.yaml
@@ -22,6 +22,7 @@
 		Footprint: xx xx
 		TerrainTypes: Rock, Concrete
 		BuildSounds: BUILD1.WAV
+	D2BuildingPlacement:
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 1
@@ -32,7 +33,6 @@
 	SoundOnDamageTransition:
 		DamagedSounds: EXPLSML1.WAV
 		DestroyedSounds: EXPLHG1.WAV
-	#WithSpriteBody:
 	WithTilesetBody:
 	Explodes:
 		Type: Footprint

--- a/mods/d2/rules/concrete.yaml
+++ b/mods/d2/rules/concrete.yaml
@@ -5,6 +5,7 @@
 		TerrainTypes: Rock
 		BuildSounds: CHUNG.WAV
 		AllowInvalidPlacement: true
+	D2BuildingPlacement:
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 1
@@ -29,7 +30,7 @@ concretea:
 	LaysTerrain:
 		Template: 126
 		TerrainTypes: Rock
-	WithSpriteBody:
+	WithTilesetBody:
 	RenderSprites:
 		Image: concretea
 	Valued:

--- a/mods/d2/rules/construction_yard.yaml
+++ b/mods/d2/rules/construction_yard.yaml
@@ -45,7 +45,7 @@ construction_yard:
 	RenderSprites:
 		Image: conyard
 		PlayerPalette: player
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	ProvidesPrerequisite@buildingname:
 	ProvidesPrerequisite@Atreides:

--- a/mods/d2/rules/defense.yaml
+++ b/mods/d2/rules/defense.yaml
@@ -1,10 +1,10 @@
 ^Defense:
 	Inherits: ^Building
-	WithSpriteTurret:
+	D2WithSpriteTurret:
 	AttackTurreted:
 	-Capturable:
 	-WithTilesetBody:
-	WithWallSpriteBody:
+	D2WithWallSpriteBody:
 	LineBuildNode:
 		Types: turret
 	MustBeDestroyed:

--- a/mods/d2/rules/heavy_factory.yaml
+++ b/mods/d2/rules/heavy_factory.yaml
@@ -61,7 +61,7 @@ heavy_factory:
 		Sequence: production-welding-1
 	WithProductionOverlay@WELDING2:
 		Sequence: production-welding-2
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	Power:
 		Amount: -35

--- a/mods/d2/rules/high_tech_factory.yaml
+++ b/mods/d2/rules/high_tech_factory.yaml
@@ -41,7 +41,7 @@ high_tech_factory:
 		Range: 3c0
 	WithTilesetBody:
 		SkipFrames: 3
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	RenderSprites:
 		Image: hightech

--- a/mods/d2/rules/light_factory.yaml
+++ b/mods/d2/rules/light_factory.yaml
@@ -31,7 +31,7 @@ light_factory:
 	RenderSprites:
 		Image: light
 		PlayerPalette: player
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding

--- a/mods/d2/rules/outpost.yaml
+++ b/mods/d2/rules/outpost.yaml
@@ -34,15 +34,17 @@ outpost:
 		PlayerPalette: player
 	RenderSprites:
 		Image: outpost
-	WithIdleOverlay@DISH:
+	D2WithIdleOverlay@DISH:
 		Sequence: idle-dish
 		PauseOnCondition: disabled
 		RequiresCondition: !severe-damaged
-        GrantConditionOnDamageState@STOPDISH:
+		GrantConditionOnDamageState@STOPDISH:
 		Condition: severe-damaged
 		ValidDamageState: Medium, Heavy, Critical
-	WithIdleOverlay@FLAG:
+		EnabledByDefault: false
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
+		EnabledByDefault: false
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2/rules/palace.yaml
+++ b/mods/d2/rules/palace.yaml
@@ -32,7 +32,7 @@ palace:
 	RenderSprites:
 		Image: palace
 		PlayerPalette: player
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	Power:
 		Amount: -80

--- a/mods/d2/rules/powerdown.yaml
+++ b/mods/d2/rules/powerdown.yaml
@@ -1,7 +1,4 @@
 ^DisableOnLowPower:
-	WithColoredOverlay@IDISABLE:
-		RequiresCondition: disabled
-		Palette: disabled
 	GrantConditionOnPowerState@LOWPOWER:
 		Condition: lowpower
 		ValidPowerStates: Low, Critical
@@ -19,12 +16,6 @@
 		EnabledSound: DisablePower
 		Condition: powerdown
 		OrderName: PowerDown
-	WithDecoration@POWERDOWN:
-		Image: poweroff
-		Sequence: offline
-		Palette: chrome
-		RequiresCondition: powerdown
-		ReferencePoint: Center
 	PowerMultiplier@POWERDOWN:
 		RequiresCondition: powerdown
 		Modifier: 0

--- a/mods/d2/rules/refinery.yaml
+++ b/mods/d2/rules/refinery.yaml
@@ -26,7 +26,7 @@ refinery:
 		Type: heavy
 	RevealsShroud:
 		Range: 4c0
-	Refinery:
+	D2Refinery:
 		DockAngle: 120
 		DockOffset: 2,1
 		TickRate: 20
@@ -40,17 +40,14 @@ refinery:
 		DeliveryOffset: 2,1
 		DeliveringActor: carryall.reinforce
 		Facing: 120
-	WithSpriteBody:
 	WithTilesetBody:
 		SkipFrames: 1,2,5
-	RenderSprites:
-		Image: refinery
 	Power:
 		Amount: -30
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
-	WithIdleOverlay@DOCK1:
+	D2WithIdleOverlay@DOCK1:
 		Sequence: idle-dock-top
-	WithIdleOverlay@DOCK2:
+	D2WithIdleOverlay@DOCK2:
 		Sequence: idle-dock-bottom
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2/rules/repair_pad.yaml
+++ b/mods/d2/rules/repair_pad.yaml
@@ -39,7 +39,7 @@ repair_pad:
 		SkipFrames: 1
 	RenderSprites:
 		Image: repair_pad
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	WithRepairOverlay@ACTIVE1:
 		Sequence: active-1

--- a/mods/d2/rules/research_centre.yaml
+++ b/mods/d2/rules/research_centre.yaml
@@ -30,7 +30,7 @@ research_centre:
 		SkipFrames: 3
 	RenderSprites:
 		Image: research
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	Power:
 		Amount: -40

--- a/mods/d2/rules/silo.yaml
+++ b/mods/d2/rules/silo.yaml
@@ -31,7 +31,7 @@ silo:
 		PipColor: green
 		PipCount: 5
 		Capacity: 2000
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	Power:
 		Amount: -5

--- a/mods/d2/rules/starport.yaml
+++ b/mods/d2/rules/starport.yaml
@@ -50,7 +50,7 @@ starport:
 	RenderSprites:
 		Image: starport
 		PlayerPalette: player
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	ProvidesPrerequisite@atreides:
 		Prerequisite: starport.atreides

--- a/mods/d2/rules/wall.yaml
+++ b/mods/d2/rules/wall.yaml
@@ -23,6 +23,7 @@ wall:
 	D2Building:
 		BuildSounds: CHUNG.WAV
 		TerrainTypes: Rock, Concrete
+	D2BuildingPlacement:
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 1
@@ -40,7 +41,7 @@ wall:
 		Height: 512
 	Targetable:
 		TargetTypes: Ground, Wall
-	WithWallSpriteBody:
+	D2WithWallSpriteBody:
 	Guardable:
 	Explodes:
 		Weapon: WallExplode

--- a/mods/d2/rules/wind_trap.yaml
+++ b/mods/d2/rules/wind_trap.yaml
@@ -30,7 +30,7 @@ wind_trap:
 	RenderSprites:
 		Image: wind_trap
 		PlayerPalette: wind
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	Power:
 		Amount: 100

--- a/mods/d2/rules/wor.yaml
+++ b/mods/d2/rules/wor.yaml
@@ -60,9 +60,9 @@ wor:
 		PlayerPalette: player
 	WithTilesetBody:
 		SkipFrames: 0, 2
-	WithIdleOverlay@FLAG:
+	D2WithIdleOverlay@FLAG:
 		Sequence: idle-flag
-	WithIdleOverlay@TOP-FLAG:
+	D2WithIdleOverlay@TOP-FLAG:
 		Sequence: idle-top-flag
 	ProvidesPrerequisite@buildingname:
 	GrantConditionOnPrerequisite:

--- a/mods/d2/sequences/concrete.yaml
+++ b/mods/d2/sequences/concrete.yaml
@@ -2,6 +2,10 @@ concretea:
 	idle: ICON.ICN
 		Start: 126
 		Offset: 0,0
+	idle-tileset: ICON.ICN
+		Frames: 126
+		Length 1
+		Offset: 0,0
 	icon: SHAPES.SHP
 		Start: 53
 		Offset: 0,0


### PR DESCRIPTION
Closes #110 

Do not draw all building sprites, just bounds rect for buildings placements

A lot of changes because need to remove `IRenderActorPreviewSpritesInfo` from all traits used for buildings