### PR TITLE
Fix outpost dish when damaged.

### DIFF
--- a/mods/d2/rules/outpost.yaml
+++ b/mods/d2/rules/outpost.yaml
@@ -37,10 +37,6 @@ outpost:
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 		PauseOnCondition: disabled
-		RequiresCondition: !severe-damaged
-	GrantConditionOnDamageState@STOPDISH:
-		Condition: severe-damaged
-		ValidDamageState: Medium, Heavy, Critical
 	WithIdleOverlay@FLAG:
 		Sequence: idle-flag
 	Power:


### PR DESCRIPTION
The removal of the anim exists in D2k because in D2k radar dish stop spinning when damaged and the actual body contains the damaged dish. We don't have damaged art on D2, so this should go.