### PR TITLE
Use custom engine in d2 mod.config

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,8 @@
 MOD_ID="d2"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="release-20190314"
+ENGINE_VERSION="release-20190314-d2"
+#ENGINE_VERSION="release-20190314"
 
 # Enable this to make the default OpenRA mods available for use in your mod.yaml
 # Packages list (via $mod references). Accepts values "True" or "False".
@@ -106,7 +107,8 @@ PACKAGING_OVERWRITE_MOD_VERSION="True"
 AUTOMATIC_ENGINE_MANAGEMENT="True"
 
 # The URL to download the engine files from when AUTOMATIC_ENGINE_MANAGEMENT is enabled.
-AUTOMATIC_ENGINE_SOURCE="https://github.com/OpenRA/OpenRA/archive/${ENGINE_VERSION}.zip"
+AUTOMATIC_ENGINE_SOURCE="https://github.com/evgeniysergeev/OpenRA/archive/${ENGINE_VERSION}.zip"
+#AUTOMATIC_ENGINE_SOURCE="https://github.com/OpenRA/OpenRA/archive/${ENGINE_VERSION}.zip"
 
 # Temporary file/directory names used by automatic engine management.
 # Paths outside the SDK directory are not officially supported.


### PR DESCRIPTION
As suggested in OpenRA#117, use custom OpenRA engine.

