### PR TITLE
Remove disabled palette

### DIFF
--- a/mods/d2/rules/palettes.yaml
+++ b/mods/d2/rules/palettes.yaml
@@ -47,12 +47,6 @@
 		G: 255
 		B: 255
 		A: 64
-	PaletteFromRGBA@disabled:
-		Name: disabled
-		R: 0
-		G: 0
-		B: 0
-		A: 180
 	PaletteFromPaletteWithAlpha@effect75alpha:
 		Name: effect75alpha
 		BasePalette: effect

--- a/mods/d2/rules/powerdown.yaml
+++ b/mods/d2/rules/powerdown.yaml
@@ -1,7 +1,4 @@
 ^DisableOnLowPower:
-	WithColoredOverlay@IDISABLE:
-		RequiresCondition: disabled
-		Palette: disabled
 	GrantConditionOnPowerState@LOWPOWER:
 		Condition: lowpower
 		ValidPowerStates: Low, Critical


### PR DESCRIPTION
Remove disabled palette.
It displays incorrectly on outpost.
powerdown outpost just stop rotating radar.

<img width="156" alt="Screen Shot 2019-05-18 at 13 03 48" src="https://user-images.githubusercontent.com/3105609/57967970-700ff180-796d-11e9-9e28-f4efac3a36f3.png">
