### PR TITLE
Add Single Selection

### DIFF
--- a/OpenRA.Mods.D2/Traits/World/D2Selection.cs
+++ b/OpenRA.Mods.D2/Traits/World/D2Selection.cs
@@ -1,0 +1,97 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits
+{
+	public class D2SelectionInfo : ITraitInfo, ILobbyOptions
+	{
+		[Translate]
+		[Desc("Descriptive label for the selection checkbox in the lobby.")]
+		public readonly string CheckboxLabel = "Single Selection";
+	
+		[Translate]
+		[Desc("Tooltip description for the selection checkbox in the lobby.")]
+		public readonly string CheckboxDescription = "Allow to select only one unit at a time";
+	
+		[Desc("Default value of the selection checkbox in the lobby.")]
+		public readonly bool CheckboxEnabled = false;
+	
+		[Desc("Prevent the selection enabled state from being changed in the lobby.")]
+		public readonly bool CheckboxLocked = false;
+	
+		[Desc("Whether to display the selection checkbox in the lobby.")]
+		public readonly bool CheckboxVisible = true;
+	
+		[Desc("Display order for the selection checkbox in the lobby.")]
+		public readonly int CheckboxDisplayOrder = 0;
+	
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("singleselection", CheckboxLabel, CheckboxDescription,
+				CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+		}
+	
+		public object Create(ActorInitializer init) { return new D2Selection(init.World, this); }
+	}
+
+	public class D2Selection : Selection
+	{
+		readonly D2SelectionInfo info;
+		readonly World world;
+	
+		bool initialized = false;
+		bool singleSelection = true;
+		public bool SingleSelection { get { return singleSelection; } }
+		
+		public D2Selection(World world, D2SelectionInfo info) : base(new SelectionInfo())
+		{
+			this.world = world;
+			this.info = info;
+		}
+
+		void Init()
+		{
+			if (!initialized)
+			{
+				var gs = world.LobbyInfo.GlobalSettings;
+				singleSelection = gs.OptionOrDefault("singleselection", info.CheckboxEnabled);
+				initialized = true;
+			}
+		}
+
+		public override void Add(Actor a)
+		{
+			Init();
+
+			if (SingleSelection)
+				Clear();
+			
+			base.Add(a);
+		}
+
+		public override void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
+		{
+			Init();
+
+			if (SingleSelection)
+			{
+				isClick = true;
+				isCombine = false;
+			}
+
+			base.Combine(world, newSelection, isCombine, isClick);
+		}
+	}
+}

--- a/mods/d2/rules/player.yaml
+++ b/mods/d2/rules/player.yaml
@@ -29,7 +29,7 @@ Player:
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
 	DeveloperMode:
-		CheckboxDisplayOrder: 5
+		CheckboxDisplayOrder: 7
 	BaseAttackNotifier:
 	Shroud:
 		FogCheckboxDisplayOrder: 3

--- a/mods/d2/rules/world.yaml
+++ b/mods/d2/rules/world.yaml
@@ -3,7 +3,11 @@
 	AlwaysVisible:
 	ScreenMap:
 	ActorMap:
-	Selection:
+	D2Selection:
+		CheckboxEnabled: True
+		CheckboxLocked: False
+		CheckboxVisible: True
+		CheckboxDisplayOrder: 1
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: score
@@ -165,7 +169,7 @@ World:
 	MapCreeps:
 		CheckboxLabel: Worms
 		CheckboxDescription: Worms roam the map and devour unprepared forces
-		CheckboxDisplayOrder: 1
+		CheckboxDisplayOrder: 5
 	SpawnMapActors:
 	MapBuildRadius:
 		AllyBuildRadiusCheckboxDisplayOrder: 4


### PR DESCRIPTION
closes #120 

Add Single Selection and use it by default. But allow to use multi-selection if uncheck ‘Single Selection’ in lobby:
<img width="548" alt="Screen Shot 2019-07-04 at 08 15 45" src="https://user-images.githubusercontent.com/3105609/60641342-18054f80-9e34-11e9-8852-e0e3b2fce675.png">

