### PR TITLE
Add sidebar panel with Actor info

### DIFF
--- a/OpenRA.Mods.D2/Widgets/D2LineWidget.cs
+++ b/OpenRA.Mods.D2/Widgets/D2LineWidget.cs
@@ -1,0 +1,47 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Widgets;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.D2.Widgets
+{
+	public class D2LineWidget : Widget
+	{
+		public int Size = 3;
+		public Func<Color> GetColor;
+
+		public D2LineWidget()
+		{
+			GetColor = () => Color.FromArgb(251, 255, 203);
+		}
+
+		protected D2LineWidget(D2LineWidget widget)
+			: base(widget)
+		{
+			GetColor = widget.GetColor;
+		}
+
+		public override Widget Clone()
+		{
+			return new D2LineWidget(this);
+		}
+
+		public override void Draw()
+		{
+			var rb = RenderBounds;
+			D2WidgetUtils.DrawLine(
+				new float2(rb.Left, rb.Top),
+				new float2(rb.Right, rb.Bottom), Size, GetColor());
+		}
+	}
+}

--- a/OpenRA.Mods.D2/Widgets/D2PanelWidget.cs
+++ b/OpenRA.Mods.D2/Widgets/D2PanelWidget.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+using OpenRA.Mods.Common.Widgets;
+
+namespace OpenRA.Mods.D2.Widgets
+{
+	public class D2PanelWidget : Widget
+	{
+		public int BarMargin = 3;
+
+		public Func<Color> GetColor;
+
+		public Action<MouseInput> OnMouseDown = _ => { };
+		public Action<MouseInput> OnMouseUp = _ => { };
+
+		public D2PanelWidget()
+		{
+			GetColor = () => Color.FromArgb(186, 190, 150);
+		}
+
+		protected D2PanelWidget(D2PanelWidget widget)
+			: base(widget)
+		{
+			GetColor = widget.GetColor;
+		}
+
+		public override Widget Clone()
+		{
+			return new D2PanelWidget(this);
+		}
+
+		public override void Draw()
+		{
+			var rb = RenderBounds;
+			WidgetUtils.FillRectWithColor(rb, GetColor());
+			D2WidgetUtils.DrawPanelBorder(rb, BarMargin);
+		}
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			if (mi.Button != MouseButton.Left)
+				return false;
+
+			if (mi.Event == MouseInputEvent.Down && !TakeMouseFocus(mi))
+				return false;
+
+			if (HasMouseFocus && mi.Event == MouseInputEvent.Up)
+			{
+				// Only fire the onMouseUp event if we successfully lost focus, and were pressed
+				OnMouseUp(mi);
+
+				return YieldMouseFocus(mi);
+			}
+
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				// OnMouseDown returns false if the button shouldn't be pressed
+				OnMouseDown(mi);
+			}
+
+			return false;
+		}
+	}
+}

--- a/OpenRA.Mods.D2/Widgets/D2ProgressBarWidget.cs
+++ b/OpenRA.Mods.D2/Widgets/D2ProgressBarWidget.cs
@@ -1,0 +1,75 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+using OpenRA.Mods.Common.Widgets;
+
+namespace OpenRA.Mods.D2.Widgets
+{
+	public class D2ProgressBarWidget : Widget
+	{
+		public int BarMargin = 3;
+
+		public int Percentage = 0;
+
+		public Func<int> GetPercentage;
+
+		public D2ProgressBarWidget()
+		{
+			GetPercentage = () => Percentage;
+		}
+
+		protected D2ProgressBarWidget(D2ProgressBarWidget other)
+			: base(other)
+		{
+			Percentage = other.Percentage;
+			GetPercentage = other.GetPercentage;
+		}
+
+		public override void Draw()
+		{
+			if (GetPercentage == null)
+				return;
+
+			var rb = RenderBounds;
+			var r = new Rectangle(rb.Left, rb.Top, rb.Width, rb.Height - 3 * BarMargin);
+
+			var percentage = GetPercentage();
+
+			var backgroundColor = Color.FromArgb(186, 190, 150);
+
+			WidgetUtils.FillRectWithColor(rb, backgroundColor);
+			D2WidgetUtils.DrawPanelBorder(r, BarMargin);
+
+			D2WidgetUtils.DrawRedTriangle(new int2(r.Left + BarMargin * 2, r.Bottom), BarMargin);
+			D2WidgetUtils.DrawYellowTriangle(new int2((r.Left + r.Right) / 2, r.Bottom), BarMargin);
+			D2WidgetUtils.DrawGreenTriangle(new int2(r.Right - 2 * BarMargin, r.Bottom), BarMargin);
+
+			var minBarWidth = 1;
+			var maxBarWidth = r.Width - BarMargin * 2;
+			var barWidth = percentage * maxBarWidth / 100;
+			barWidth = Math.Max(barWidth, minBarWidth);
+
+			var barRect = new Rectangle(r.X + BarMargin, r.Y + BarMargin, barWidth, r.Height - 2 * BarMargin);
+			var barColor = Color.FromArgb(85, 254, 81);
+			if (percentage < 25)
+				barColor = Color.FromArgb(168, 0, 0);
+			else if (percentage < 50)
+				barColor = Color.FromArgb(254, 251, 84);
+
+			WidgetUtils.FillRectWithColor(barRect, barColor);
+		}
+
+		public override Widget Clone() { return new D2ProgressBarWidget(this); }
+	}
+}

--- a/OpenRA.Mods.D2/Widgets/D2SpriteWidget.cs
+++ b/OpenRA.Mods.D2/Widgets/D2SpriteWidget.cs
@@ -1,0 +1,57 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Network;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.D2.Widgets
+{
+	public class D2SpriteWidget : Widget
+	{
+		public readonly World World;
+
+		public Sprite Sprite = null;
+		public PaletteReference Palette = null;
+		public float2 Offset = float2.Zero;
+		public float Scale = 1.0f;
+
+		readonly WorldRenderer worldRenderer;
+
+		[ObjectCreator.UseCtor]
+		public D2SpriteWidget(World world, WorldRenderer worldRenderer)
+		{
+			World = world;
+			this.worldRenderer = worldRenderer;
+		}
+
+		public override void Draw()
+		{
+			if (Sprite == null)
+				return;
+
+			var pos = new float2(RenderBounds.Location);
+			var f = Scale / 2.0f;
+			var center = new float2(Sprite.Size.X * f, Sprite.Size.Y * f);
+
+			WidgetUtils.DrawSHPCentered(Sprite, pos + center + Offset, Palette, Scale);
+		}
+	}
+}

--- a/OpenRA.Mods.D2/Widgets/D2WidgetUtils.cs
+++ b/OpenRA.Mods.D2/Widgets/D2WidgetUtils.cs
@@ -1,0 +1,101 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Primitives;
+using OpenRA.Mods.Common.Widgets;
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.D2.Widgets
+{
+	public static class D2WidgetUtils
+	{
+		public static void DrawLine(float2 start, float2 end, float width, Color color)
+		{
+			// Offset to the edges of the pixels
+			var a = new float2(start.X - 0.5f, start.Y - 0.5f);
+			var b = new float2(end.X - 0.5f, end.Y - 0.5f);
+			Game.Renderer.RgbaColorRenderer.DrawLine(a, b, width, color);
+		}
+
+		public static void DrawDisconnectedLine(IEnumerable<float2> points, float width, Color color)
+		{
+			using (var e = points.GetEnumerator())
+			{
+				if (!e.MoveNext())
+					return;
+
+				var lastPoint = e.Current;
+				while (e.MoveNext())
+				{
+					var point = e.Current;
+					DrawLine(lastPoint, point, width, color);
+					lastPoint = point;
+				}
+			}
+		}
+
+		public static void DrawColoredPanelBorder(Rectangle bounds, int size, Color highlightColor, Color shadowColor)
+		{
+			WidgetUtils.FillRectWithColor(new Rectangle(bounds.Left, bounds.Top, size, bounds.Height - size), highlightColor);
+			WidgetUtils.FillRectWithColor(new Rectangle(bounds.Left, bounds.Top, bounds.Width - size, size), highlightColor);
+			
+			WidgetUtils.FillRectWithColor(new Rectangle(bounds.Left + size, bounds.Bottom - size, bounds.Width - size, size), shadowColor);
+			WidgetUtils.FillRectWithColor(new Rectangle(bounds.Right - size, bounds.Top + size, size, bounds.Height - size), shadowColor);
+		}
+
+		public static void DrawPanelBorder(Rectangle bounds, int size)
+		{
+			var highlightColor = Color.FromArgb(251, 255, 203);
+			var shadowColor = Color.FromArgb(103, 103, 79);
+
+			DrawColoredPanelBorder(bounds, size, highlightColor, shadowColor);
+		}
+
+		public static void DrawColoredTriangle(int2 a, int size, Color normalColor, Color highlightColor, Color shadowColor)
+		{
+			WidgetUtils.FillRectWithColor(new Rectangle(a.X - size, a.Y, size, size * 2), highlightColor);
+
+			WidgetUtils.FillRectWithColor(new Rectangle(a.X - size * 2, a.Y + size, size, size), normalColor);
+			WidgetUtils.FillRectWithColor(new Rectangle(a.X, a.Y + size, size, size), normalColor);
+
+			WidgetUtils.FillRectWithColor(new Rectangle(a.X, a.Y, size, size), shadowColor);
+			WidgetUtils.FillRectWithColor(new Rectangle(a.X + size, a.Y + size, size, size * 2), shadowColor);
+			WidgetUtils.FillRectWithColor(new Rectangle(a.X - size * 2, a.Y + size * 2, size * 3, size), shadowColor);
+		}
+
+		public static void DrawRedTriangle(int2 a, int size)
+		{
+			var normalColor = Color.FromArgb(124, 0, 0);
+			var highlightColor = Color.FromArgb(180, 0, 0);
+			var shadowColor = Color.Black;
+
+			DrawColoredTriangle(a, size, normalColor, highlightColor, shadowColor);
+		}
+
+		public static void DrawYellowTriangle(int2 a, int size)
+		{
+			var normalColor = Color.FromArgb(252, 184, 86);
+			var highlightColor = Color.FromArgb(252, 252, 84);
+			var shadowColor = Color.Black;
+
+			DrawColoredTriangle(a, size, normalColor, highlightColor, shadowColor);
+		}
+
+		public static void DrawGreenTriangle(int2 a, int size)
+		{
+			var normalColor = Color.FromArgb(0, 168, 0);
+			var highlightColor = Color.FromArgb(84, 252, 84);
+			var shadowColor = Color.Black;
+
+			DrawColoredTriangle(a, size, normalColor, highlightColor, shadowColor);
+		}
+	}
+}

--- a/OpenRA.Mods.D2/Widgets/Logic/Ingame/D2IngameActorInfoDisplayLogic.cs
+++ b/OpenRA.Mods.D2/Widgets/Logic/Ingame/D2IngameActorInfoDisplayLogic.cs
@@ -1,0 +1,275 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.D2.Widgets.Logic
+{
+	public class D2IngameActorInfoDisplayLogic : ChromeLogic
+	{
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
+
+		readonly D2PanelWidget panel;
+		readonly LabelWidget label;
+		readonly D2SpriteWidget preview;
+		readonly D2ProgressBarWidget health;
+		readonly LabelWidget dmgLabel;
+
+		readonly D2LineWidget separator;
+		readonly LabelWidget title;
+		readonly LabelWidget line1a;
+		readonly LabelWidget line1b;
+		readonly LabelWidget line2a;
+		readonly LabelWidget line2b;
+
+		int selectionHash;
+		Actor[] selectedActors = { };
+
+		[ObjectCreator.UseCtor]
+		public D2IngameActorInfoDisplayLogic(Widget widget, World world, WorldRenderer worldRenderer)
+		{
+			this.world = world;
+			this.worldRenderer = worldRenderer;
+
+			var textColor = Color.FromArgb(71, 71, 55);
+
+			panel = widget.GetOrNull<D2PanelWidget>("PANEL");
+
+			label = widget.GetOrNull<LabelWidget>("NAME");
+			if (label != null)
+			{
+				label.Align = TextAlign.Center;
+				label.TextColor = textColor;
+				label.Font = "MediumBold";
+			}
+
+			preview = widget.GetOrNull<D2SpriteWidget>("ICON");
+
+			health = widget.GetOrNull<D2ProgressBarWidget>("HEALTH");
+
+			dmgLabel = widget.GetOrNull<LabelWidget>("DMG");
+			if (dmgLabel != null)
+			{
+				dmgLabel.Text = "DMG";
+				dmgLabel.Align = TextAlign.Center;
+				dmgLabel.TextColor = textColor;
+				dmgLabel.Font = "MediumBold";
+			}
+
+			title = widget.GetOrNull<LabelWidget>("TITLE");
+			if (title != null)
+			{
+				title.Align = TextAlign.Center;
+				title.TextColor = textColor;
+				title.Font = "MediumBold";
+			}
+
+			separator = widget.GetOrNull<D2LineWidget>("SEPARATOR");
+
+			line1a = widget.GetOrNull<LabelWidget>("LINE1A");
+			if (line1a != null)
+			{
+				line1a.TextColor = textColor;
+				line1a.Font = "MediumBold";
+			}
+
+			line1b = widget.GetOrNull<LabelWidget>("LINE1B");
+			if (line1b != null)
+			{
+				line1b.Align = TextAlign.Right;
+				line1b.TextColor = textColor;
+				line1b.Font = "MediumBold";
+			}
+
+			line2a = widget.GetOrNull<LabelWidget>("LINE2A");
+			if (line2a != null)
+			{
+				line2a.TextColor = textColor;
+				line2a.Font = "MediumBold";
+			}
+
+			line2b = widget.GetOrNull<LabelWidget>("LINE2B");
+			if (line2b != null)
+			{
+				line2b.Align = TextAlign.Right;
+				line2b.TextColor = textColor;
+				line2b.Font = "MediumBold";
+			}
+		}
+		public override void Tick()
+		{
+			base.Tick();
+
+			UpdateStateIfNecessary();
+		}
+
+		void HideExtraInfo()
+		{
+			if (title == null || separator == null || line1a == null || line1b == null || line2a == null || line2b == null)
+				return;
+
+			title.Visible = false;
+			separator.Visible = false;
+			line1a.Visible = false;
+			line1b.Visible = false;
+			line2a.Visible = false;
+			line2b.Visible = false;
+		}
+
+		void UpdateSpiceInfo(Actor actor)
+		{
+			if (title == null || separator == null || line1a == null || line1b == null || line2a == null || line2b == null)
+				return;
+
+			var stores = actor.TraitsImplementing<StoresResources>();
+			if (stores.Any())
+			{
+				var store = stores.FirstOrDefault();
+				if (store != null)
+				{
+					title.Text = "SPICE";
+					title.Visible = true;
+
+					separator.Visible = true;
+
+					line1a.Text = "HOLDS:";
+					line1a.Visible = true;
+					line1b.GetText = () => store.Stored.ToString();
+					line1b.Visible = true;
+
+					line2a.Text = "MAX:";
+					line2a.Visible = true;
+					line2b.GetText = () => (store as IStoreResources).Capacity.ToString();
+					line2b.Visible = true;
+				}
+			}
+		}
+
+		void UpdatePowerInfo(Actor actor)
+		{
+			if (title == null || separator == null || line1a == null || line1b == null || line2a == null || line2b == null)
+				return;
+
+			var powers = actor.TraitsImplementing<Power>();
+			if (powers.Any())
+			{
+				var power = powers.FirstOrDefault(t => !t.IsTraitDisabled);
+				if (power != null)
+				{
+					if (power.Info.Amount > 0)
+					{
+						title.Text = "POWER INFO";
+						title.Visible = true;
+
+						separator.Visible = true;
+
+						line1a.Text = "NEEDED:";
+						line1a.Visible = true;
+						line1b.GetText = () => (power.PlayerPower.PowerProvided != 0 ? power.PlayerPower.PowerDrained * power.GetEnabledPower() / power.PlayerPower.PowerProvided : 0).ToString();
+						line1b.Visible = true;
+
+						line2a.Text = "OUTPUT:";
+						line2a.Visible = true;
+						line2b.GetText = () => power.GetEnabledPower().ToString();
+						line2b.Visible = true;
+					}
+				}
+			}
+		}
+
+
+		void UpdateStateIfNecessary()
+		{
+			if (selectionHash == world.Selection.Hash)
+				return;
+
+			selectedActors = world.Selection.Actors
+				.Where(a => a.IsInWorld && !a.IsDead)
+				.ToArray();
+
+			if (selectedActors.Length == 1)
+			{
+				var actor = selectedActors[0];
+				if (label != null)
+				{
+					var tooltip = actor.TraitsImplementing<Tooltip>();
+					if (tooltip.Any())
+						label.Text = tooltip.FirstOrDefault(t => !t.IsTraitDisabled).Info.Name;
+					else
+						label.Text = actor.Info.Name;
+				}
+
+				var faction = world.LocalPlayer.Faction.Name;
+				var rsi = actor.Info.TraitInfo<RenderSpritesInfo>();
+				var icon = new Animation(world, rsi.GetImage(actor.Info, world.Map.Rules.Sequences, faction));
+				var bi = actor.Info.TraitInfo<BuildableInfo>();
+				icon.Play(bi.Icon);
+
+				if (preview != null)
+				{
+					preview.Sprite = icon.Image;
+					preview.Palette = worldRenderer.Palette(bi.IconPalette);
+					preview.Scale = 3.0f;
+					preview.Offset = float2.Zero;
+				}
+
+				if (health != null)
+				{
+					var healthTrait = actor.TraitsImplementing<Health>();
+					if (healthTrait.Any())
+					{
+						health.GetPercentage = () =>
+						{
+							var h = healthTrait.FirstOrDefault();
+							return (h != null) ? h.HP * 100 / h.MaxHP : 0;
+						};
+						health.Visible = true;
+					}
+					else
+					{
+						health.GetPercentage = () => 0;
+						health.Visible = false;
+					}
+				}
+
+				if (dmgLabel != null)
+					dmgLabel.Visible = true;
+
+				HideExtraInfo();
+				UpdateSpiceInfo(actor);
+				UpdatePowerInfo(actor);
+			}
+			else
+			{
+				if (preview != null)
+					preview.Sprite = null;
+				if (label != null)
+					label.Text = "";
+				if (health != null)
+					health.Visible = false;
+				if (dmgLabel != null)
+					dmgLabel.Visible = false;
+
+				HideExtraInfo();
+			}
+
+			selectionHash = world.Selection.Hash;
+		}
+	}
+}

--- a/mods/d2/chrome/ingame-player.yaml
+++ b/mods/d2/chrome/ingame-player.yaml
@@ -504,3 +504,75 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: scrollbar
 									ImageName: down_arrow
+		Container@ACTOR_INFO:
+			Logic: D2IngameActorInfoDisplayLogic
+			X: WINDOW_RIGHT - 226 - 218
+			Y: 14
+			Width: 218
+			Height: 256
+			ClickThrough: false
+			Children:
+				D2Panel@PANEL:
+					X: 0
+					Y: 12
+					Width: 218
+					Height: 256
+				Label@NAME:
+					X: 4
+					Y: 10
+					Width: 218
+					Height: 32
+				D2Sprite@ICON:
+					X: 20
+					Y: 42
+					Width: 64
+					Height: 48
+				D2ProgressBar@HEALTH:
+					X: 128
+					Y: 42
+					Width: 72
+					Height: 40
+					Visible: false
+				Label@DMG:
+					X: 128
+					Y: 88
+					Width: 72
+					Height: 16
+					Visible: false
+				Label@TITLE:
+					X: 4
+					Y: 164
+					Width: 218
+					Height: 16
+					Visible: false
+				D2Line@SEPARATOR:
+					X: 32
+					Y: 186
+					Width: 154
+					Height: 0
+					Visible: false
+				Label@LINE1A:
+					X: 20
+					Y: 188
+					Width: 88
+					Height: 16
+					Visible: false
+				Label@LINE1B:
+					X: 110
+					Y: 188
+					Width: 88
+					Height: 16
+					Visible: false
+				Label@LINE2A:
+					X: 20
+					Y: 208
+					Width: 88
+					Height: 16
+					Visible: false
+				Label@LINE2B:
+					X: 110
+					Y: 208
+					Width: 88
+					Height: 16
+					Visible: false
+


### PR DESCRIPTION
Closes #124

Add sidebar with information about currently selected unit or building.
Note that sidebar from d2k will be removed, when d2 sidebar will be finished

<img width="667" alt="Screen Shot 2019-07-10 at 01 53 08" src="https://user-images.githubusercontent.com/3105609/60928295-7fe4eb80-a2b5-11e9-853f-bc9390f028fb.png">
