### PR TITLE
Remove reference to System.Drawing from mod.config

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -134,4 +134,4 @@ WHITELISTED_THIRDPARTY_ASSEMBLIES="ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary
 
 # These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
 # This list *must* be kept in sync with the files packaged by the AppImageSupport and OpenRALauncherOSX repositories
-WHITELISTED_CORE_ASSEMBLIES="mscorlib.dll System.dll System.Configuration.dll System.Core.dll System.Numerics.dll System.Security.dll System.Xml.dll Mono.Security.dll OpenRA.Mods.Cnc.dll System.Drawing.dll"
+WHITELISTED_CORE_ASSEMBLIES="mscorlib.dll System.dll System.Configuration.dll System.Core.dll System.Numerics.dll System.Security.dll System.Xml.dll Mono.Security.dll"


### PR DESCRIPTION
Need to update with latest modSdk and remove references to Sytem.Drawing from mod.config.
Because of this: https://github.com/OpenRA/d2/issues/140#issuecomment-536227264