### PR TITLE
Update OpenRA engine to bleed 980c1e1 (2019-11-20)

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="d2"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="release-20191117"
+ENGINE_VERSION="980c1e1"
 
 # .dll filenames compiled by the mod solution for use by the runtime assembly check
 WHITELISTED_MOD_ASSEMBLIES="OpenRA.Mods.D2.dll"

--- a/mods/d2/chrome/assetbrowser.yaml
+++ b/mods/d2/chrome/assetbrowser.yaml
@@ -140,7 +140,7 @@ Background@ASSETBROWSER_PANEL:
 							ImageCollection: music
 							ImageName: play
 				Button@BUTTON_PAUSE:
-					Visible: no
+					Visible: false
 					X: 35
 					Y: 0
 					Width: 25

--- a/mods/d2/weapons/largeguns.yaml
+++ b/mods/d2/weapons/largeguns.yaml
@@ -5,7 +5,7 @@
 	Projectile: Bullet
 		Speed: 875
 		Blockable: false
-		Shadow: no
+		Shadow: false
 		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
@@ -63,7 +63,7 @@ DevBullet:
 	Projectile: Bullet
 		Speed: 192
 		Blockable: false
-		Shadow: yes
+		Shadow: true
 		LaunchAngle: 62
 		Inaccuracy: 768
 		#ContrailLength: 20


### PR DESCRIPTION
Next change in d2 (Related to #149) will need changes in OpenRA engine (in Sheet.cs, ChromeProvider.cs and other UI related stuff).
Better to switch to bleed now, and when changes in engine will be merged, just use it from bleed.
Currently bleed contain only two UpdateRules and commit in this PR is trivial.