### PR TITLE
Remove ResourceRenderer from world.yaml (keep D2ResourceRenderer only)

### DIFF
--- a/mods/d2/rules/world.yaml
+++ b/mods/d2/rules/world.yaml
@@ -269,8 +269,6 @@ World:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
 	TimeLimitManager:
-	ResourceRenderer:
-		RenderTypes:
 
 EditorWorld:
 	Inherits: ^BaseWorld


### PR DESCRIPTION
Closes #185 