### PR TITLE
Draw tracks like in original

### DIFF
--- a/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
@@ -63,7 +63,8 @@ namespace OpenRA.Mods.D2.Traits.Render
 		int cachedInterval;
 
 		WPos cachedPosition;
-		CPos previosSpawnCell = new CPos(-1, -1);
+		bool previouslySpawned = false;
+		CPos previosSpawnCell;
 		int previousSpawnFacing;
 
 		public D2LeavesTracks(Actor self, D2LeavesTracksInfo info)
@@ -114,7 +115,7 @@ namespace OpenRA.Mods.D2.Traits.Render
 				{
 					int spawnFacing;
 
-					if (previosSpawnCell.Equals(spawnCell))
+					if (previouslySpawned && previosSpawnCell.Equals(spawnCell))
 						spawnFacing = previousSpawnFacing;
 					else
 						spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : (facing != null ? facing.Facing : 0);
@@ -124,6 +125,8 @@ namespace OpenRA.Mods.D2.Traits.Render
 
 					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, WAngle.FromFacing(spawnFacing), self.World, Info.Image,
 						Info.Sequence, Info.Palette, Info.VisibleThroughFog)));
+
+					previouslySpawned = true;
 					previosSpawnCell = spawnCell;
 					previousSpawnFacing = spawnFacing;
 				}

--- a/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
@@ -66,7 +66,6 @@ namespace OpenRA.Mods.D2.Traits.Render
 		CPos previosSpawnCell = new CPos(-1, -1);
 		int previousSpawnFacing;
 
-
 		public D2LeavesTracks(Actor self, D2LeavesTracksInfo info)
 			: base(info)
 		{

--- a/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
+++ b/OpenRA.Mods.D2/Traits/Render/D2LeavesTracks.cs
@@ -1,0 +1,133 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The d2 mod Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2.Traits.Render
+{
+	[Desc("Renders tracks when vechicle leaving a cell.")]
+	public class D2LeavesTracksInfo : ConditionalTraitInfo
+	{
+		public readonly string Image = null;
+
+		[SequenceReference("Image")]
+		public readonly string Sequence = "idle";
+
+		[PaletteReference]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
+		[Desc("Only leave trail on listed terrain types. Leave empty to leave trail on all terrain types.")]
+		public readonly HashSet<string> TerrainTypes = new HashSet<string>();
+
+		[Desc("Should the trail be visible through fog.")]
+		public readonly bool VisibleThroughFog = false;
+
+		[Desc("Display a trail while stationary.")]
+		public readonly bool TrailWhileStationary = false;
+
+		[Desc("Delay between trail updates when stationary.")]
+		public readonly int StationaryInterval = 0;
+
+		[Desc("Display a trail while moving.")]
+		public readonly bool TrailWhileMoving = true;
+
+		[Desc("Delay between trail updates when moving.")]
+		public readonly int MovingInterval = 0;
+
+		[Desc("Delay before first trail.",
+			"Use negative values for falling back to the *Interval values.")]
+		public readonly int StartDelay = 0;
+
+		[Desc("Should the trail spawn relative to last position or current position?")]
+		public readonly bool SpawnAtLastPosition = true;
+
+		public override object Create(ActorInitializer init) { return new D2LeavesTracks(init.Self, this); }
+	}
+
+	public class D2LeavesTracks : ConditionalTrait<D2LeavesTracksInfo>, ITick
+	{
+		BodyOrientation body;
+		IFacing facing;
+		int cachedFacing;
+		int cachedInterval;
+
+		public D2LeavesTracks(Actor self, D2LeavesTracksInfo info)
+			: base(info)
+		{
+			cachedInterval = Info.StartDelay;
+		}
+
+		WPos cachedPosition;
+		protected override void Created(Actor self)
+		{
+			body = self.Trait<BodyOrientation>();
+			facing = self.TraitOrDefault<IFacing>();
+			cachedFacing = facing != null ? facing.Facing : 0;
+			cachedPosition = self.CenterPosition;
+
+			base.Created(self);
+		}
+
+		int ticks;
+		bool wasStationary;
+		bool isMoving;
+
+		void ITick.Tick(Actor self)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			wasStationary = !isMoving;
+			isMoving = self.CenterPosition != cachedPosition;
+			if ((isMoving && !Info.TrailWhileMoving) || (!isMoving && !Info.TrailWhileStationary))
+				return;
+
+			if (isMoving == wasStationary && (Info.StartDelay > -1))
+			{
+				cachedInterval = Info.StartDelay;
+				ticks = 0;
+			}
+
+			if (++ticks >= cachedInterval)
+			{
+				var spawnCell = Info.SpawnAtLastPosition ? self.World.Map.CellContaining(cachedPosition) : self.World.Map.CellContaining(self.CenterPosition);
+				if (!self.World.Map.Contains(spawnCell))
+					return;
+
+				var type = self.World.Map.GetTerrainInfo(spawnCell).Type;
+
+				var spawnPosition = Info.SpawnAtLastPosition ? cachedPosition : self.CenterPosition;
+
+				var pos = self.World.Map.CenterOfCell(spawnCell);
+
+				var spawnFacing = Info.SpawnAtLastPosition ? cachedFacing : (facing != null ? facing.Facing : 0);
+
+				if ((Info.TerrainTypes.Count == 0 || Info.TerrainTypes.Contains(type)) && !string.IsNullOrEmpty(Info.Image))
+					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, WAngle.FromFacing(spawnFacing), self.World, Info.Image,
+						Info.Sequence, Info.Palette, Info.VisibleThroughFog)));
+
+				cachedPosition = self.CenterPosition;
+				cachedFacing = facing != null ? facing.Facing : 0;
+				ticks = 0;
+
+				cachedInterval = isMoving ? Info.MovingInterval : Info.StationaryInterval;
+			}
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			cachedPosition = self.CenterPosition;
+		}
+	}
+}

--- a/mods/d2/mod.yaml
+++ b/mods/d2/mod.yaml
@@ -160,7 +160,7 @@ Sequences:
 	d2|sequences/atomic.yaml
 	d2|sequences/colorpicker.yaml
 	d2|sequences/trails.yaml
-	d2|sequences/vechicle_trail.yaml
+	d2|sequences/tracks.yaml
 	d2|sequences/spicebloom.yaml
 
 TileSets:

--- a/mods/d2/rules/harvester.yaml
+++ b/mods/d2/rules/harvester.yaml
@@ -55,8 +55,3 @@ harvester:
 		Position: BottomLeft
 		RequiresSelection: true
 		PipCount: 7
-	D2LeavesTracks:
-		Image: track
-		Palette: d2
-		Type: Cell
-		TerrainTypes: Sand, Dune

--- a/mods/d2/rules/harvester.yaml
+++ b/mods/d2/rules/harvester.yaml
@@ -55,3 +55,8 @@ harvester:
 		Position: BottomLeft
 		RequiresSelection: true
 		PipCount: 7
+	D2LeavesTracks:
+		Image: track
+		Palette: d2
+		Type: Cell
+		TerrainTypes: Sand, Dune

--- a/mods/d2/rules/vechicle.yaml
+++ b/mods/d2/rules/vechicle.yaml
@@ -42,8 +42,8 @@
 		Duration: 100
 		Radius: 2c512
 	WithDamageOverlay:
-	LeavesTrails:
-		Image: vtrail
+	D2LeavesTracks:
+		Image: track
 		Palette: d2
 		Type: Cell
 		TerrainTypes: Sand, Dune, Spice

--- a/mods/d2/sequences/tracks.yaml
+++ b/mods/d2/sequences/tracks.yaml
@@ -1,4 +1,4 @@
-vtrail:
+track:
 	idle: ICON.ICN
 		Start: 25
 		Length: 1


### PR DESCRIPTION
Closes #184 

Instead of waiting fix in `LeavesTrails` in upstream in OpenRA/OpenRA#18228
Make modified trait for d2 tracks.

In original, tracks do not overlap when vehicle change direction, like on this screenshoot:
<img width="367" alt="Screenshot 2020-06-06 at 23 52 48" src="https://user-images.githubusercontent.com/3105609/83979541-c7d21f80-a917-11ea-890d-19cb91f40a23.png">
 But `LeavesTrails` trait can't do like this, it will draw multiple tracks when vechicle rotating on the same position.